### PR TITLE
update zookeeper.sh

### DIFF
--- a/zookeeper/zookeeper.sh
+++ b/zookeeper/zookeeper.sh
@@ -39,9 +39,9 @@ dataDir=/var/lib/zookeeper
 clientPort=2181
 initLimit=5
 syncLimit=2
-server.1=${CLUSTER_NAME}-m.c.hadoop-cloud-dev.google.com.internal:2888:3888
-server.2=${CLUSTER_NAME}-w-0.c.hadoop-cloud-dev.google.com.internal:2888:3888
-server.3=${CLUSTER_NAME}-w-1.c.hadoop-cloud-dev.google.com.internal:2888:3888
+server.1=${CLUSTER_NAME}-m:2888:3888
+server.2=${CLUSTER_NAME}-w-0:2888:3888
+server.3=${CLUSTER_NAME}-w-1:2888:3888
 EOF
 
 # Start ZooKeeper


### PR DESCRIPTION
When i use dataproc, i find this shell script is wrong: as follows: 
root@cluster-1-w-2:~/zookeeper-3.4.6/bin# ping cluster-1-w-0.c.hadoop-cloud-dev.google.com.internal
ping: unknown host cluster-1-w-0.c.hadoop-cloud-dev.google.com.internal

root@cluster-1-w-2:~/zookeeper-3.4.6/bin# ping cluster-1-w-0
PING cluster-1-w-0.c.gcp-test-1252.internal (10.128.0.4) 56(84) bytes of data.
64 bytes from cluster-1-w-0.c.gcp-test-1252.internal (10.128.0.4): icmp_seq=1 ttl=64 time=0.634 ms
64 bytes from cluster-1-w-0.c.gcp-test-1252.internal (10.128.0.4): icmp_seq=2 ttl=64 time=0.305 ms