### PR TITLE
Fix presto memory configs, update to latest release.

### DIFF
--- a/presto/presto.sh
+++ b/presto/presto.sh
@@ -20,7 +20,7 @@ HOSTNAME=$(hostname)
 DNSNAME=$(dnsdomainname)
 FQDN=${HOSTNAME}.$DNSNAME
 CONNECTOR_JAR=$(find /usr/lib/hadoop/lib -name 'gcs-connector-*.jar')
-PRESTO_VERSION="0.126"
+PRESTO_VERSION="0.144.1"
 HTTP_PORT="8080"
 
 # Download and unpack Presto server
@@ -48,9 +48,37 @@ connector.name=hive-hadoop2
 hive.metastore.uri=thrift://localhost:9083
 EOF
 
+# Compute memory settings based on Spark's settings.
+# We use "tail -n 1" since overrides are applied just by order of appearance.
+SPARK_EXECUTOR_MB=$(grep spark.executor.memory /etc/spark/conf/spark-defaults.conf | tail -n 1 | cut -d '=' -f 2 | cut -d 'm' -f 1)
+SPARK_EXECUTOR_CORES=$(grep spark.executor.cores /etc/spark/conf/spark-defaults.conf | tail -n 1 | cut -d '=' -f 2)
+SPARK_EXECUTOR_OVERHEAD_MB=$(grep spark.yarn.executor.memoryOverhead /etc/spark/conf/spark-defaults.conf | tail -n 1 | cut -d '=' -f 2)
+SPARK_EXECUTOR_COUNT=$(( $(nproc) / ${SPARK_EXECUTOR_CORES} ))
+
+# Add up overhead and allocated executor MB for container size.
+SPARK_CONTAINER_MB=$(( ${SPARK_EXECUTOR_MB} + ${SPARK_EXECUTOR_OVERHEAD_MB} ))
+PRESTO_JVM_MB=$(( ${SPARK_CONTAINER_MB} * ${SPARK_EXECUTOR_COUNT} ))
+
+# Give query.max-memorr-per-node 60% of Xmx; this more-or-less assumes a
+# single-tenant use case rather than trying to allow many concurrent queries
+# against a shared cluster.
+# Subtract out SPARK_EXECUTOR_OVERHEAD_MB in both the query MB and reserved
+# system MB as a crude approximation of other unaccounted overhead that we need
+# to leave betweenused bytes and Xmx bytes. Rounding down by integer division
+# here also effectively places round-down bytes in the "general" pool.
+PRESTO_QUERY_NODE_MB=$(( ${PRESTO_JVM_MB} * 6 / 10 - ${SPARK_EXECUTOR_OVERHEAD_MB} ))
+PRESTO_RESERVED_SYSTEM_MB=$(( ${PRESTO_JVM_MB} * 4 / 10 - ${SPARK_EXECUTOR_OVERHEAD_MB} ))
+
+# Compute the distributed max-memory by multiplying worker count by the
+# per-worker memory allocations.
+# TODO(dhuo): Maybe just set distributed MB cap to some infinite value so that
+# scaling up works.
+WORKER_COUNT=$(/usr/share/google/get_metadata_value attributes/dataproc-worker-count)
+PRESTO_QUERY_DISTIBUTED_MB=$(( ${WORKER_COUNT} * ${PRESTO_QUERY_NODE_MB} ))
+
 cat > presto-server-${PRESTO_VERSION}/etc/jvm.config <<EOF
 -server
--Xmx$(grep spark.executor.memory /etc/spark/conf/spark-defaults.conf | awk '{print $2}')
+-Xmx${PRESTO_JVM_MB}m
 -Xmn512m
 -XX:+UseConcMarkSweepGC
 -XX:+ExplicitGCInvokesConcurrent
@@ -71,8 +99,9 @@ if [[ "${ROLE}" == 'Master' ]]; then
 coordinator=true
 node-scheduler.include-coordinator=false
 http-server.http.port=${HTTP_PORT}
-query.max-memory=50GB
-query.max-memory-per-node=1GB
+query.max-memory=${PRESTO_QUERY_DISTIBUTED_MB}MB
+query.max-memory-per-node=${PRESTO_QUERY_NODE_MB}MB
+resources.reserved-system-memory=${PRESTO_RESERVED_SYSTEM_MB}MB
 discovery-server.enabled=true
 discovery.uri=http://${PRESTO_MASTER_FQDN}:${HTTP_PORT}
 EOF
@@ -85,9 +114,10 @@ else
 	PRESTO_MASTER_FQDN=${MASTER_NODE_NAME}-m.${DNSNAME}
 	cat > presto-server-${PRESTO_VERSION}/etc/config.properties <<EOF
 coordinator=false
-http-server.http.port=8080
-query.max-memory=50GB
-query.max-memory-per-node=1GB
+http-server.http.port=${HTTP_PORT}
+query.max-memory=${PRESTO_QUERY_DISTIBUTED_MB}MB
+query.max-memory-per-node=${PRESTO_QUERY_NODE_MB}MB
+resources.reserved-system-memory=${PRESTO_RESERVED_SYSTEM_MB}MB
 discovery.uri=http://${PRESTO_MASTER_FQDN}:${HTTP_PORT}
 EOF
 fi


### PR DESCRIPTION
Instead of using fixed defaults, configure query-per-node memory,
distributed total memory, and system reserved memory with help
from the cluster's spark executor configs.

Update to version 0.144.1.