### PR TITLE
ENH: Allow install-conda-env.sh to access conda env create functionality

### DIFF
--- a/conda/README.MD
+++ b/conda/README.MD
@@ -2,15 +2,16 @@
 
 ## Overview
 
-This folder contains initialization actions for getting up and going using Miniconda, providing use of both:
+This folder contains initialization actions for use Miniconda / conda, who can be introduced as:
  
 - [Minconda](http://conda.pydata.org/miniconda.html), a barebones version of [Anaconda](https://www.continuum.io/why-anaconda) of an open source (and totally legit) Python distro from Continuum Analytics, alongside,
-- [conda](http://conda.pydata.org/docs/), an open source (and amazing) package management system and environment management system.
+- [conda](http://conda.pydata.org/docs/), an open source (and amazing) package and environment management system.
 
-This allows Dataproc users to quickly and easily provision a Dataproc cluster leveraging conda's powerful package and environment management capabilities, including use of [conda environment definitions](https://github.com/conda/conda-env#environment-file-example).
+This allows Dataproc users to quickly and easily provision a Dataproc cluster leveraging conda's powerful management capabilities, by specifying a list of conda and / or pip packages along with use of [conda environment definitions](https://github.com/conda/conda-env#environment-file-example). All configuration is exposed via environment variables set to sane point-and-shoot defaults.
 
-A real world example of this, to be used in a bash shell script, is as follows:
+An example, to be used in a bash shell script:
 
+```
 gcloud dataproc clusters create my-dataproc-cluster \
     --initialization-actions \
         gs://dataproc-initialization-actions/jupyter/create-my-cluster.sh \
@@ -31,47 +32,49 @@ echo "Downloading conda environment at $CONDA_ENV_YAML_GSC_LOC to $CONDA_ENV_YAM
 gsutil -m cp -r $CORAL_ENV_YAML_GSC_LOC $CONDA_ENV_YAML_PATH
 
 # Install Miniconda / conda
-./dataproc-initialization-actions/conda/install-conda-env.sh
-# Install conda environment (provides dependencies)
+./dataproc-initialization-actions/conda/bootstrap-conda.sh
+# Create conda environment via conda yaml
 CONDA_ENV_YAML=$CONDA_ENV_YAML_PATH ./dataproc-initialization-actions/conda/install-conda-env.sh
+
 ```
 
 ## Details 
 
 ### bootstrap-conda.sh
 
-`bootstrap-conda.sh` contains logic for quickly configuring and installing Miniconda across the dataproc cluster, with configuration exposed via sane environment variables with point-and-shoot defaults, including:
-
-- Miniconda version, defaults to Python 3 version, [`Miniconda3-latest-Linux-x86_64.sh`](https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh), however, users can easily config for targeted versions via th following env vars (see script source for all options):
+`bootstrap-conda.sh` contains logic for quickly configuring and installing Miniconda across the dataproc cluster. Defaults to [`Miniconda3-latest-Linux-x86_64.sh`](https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh) package (e.g., Python 3), however, users can easily config for targeted versions via the following env vars (see script source for all options):
     - `MINICONDA_VARIANT`: the Python version can be `2` or `3`
     - `MINICONDA_VER`: the Miniconda version (e.g., `4.0.5`)
- 
-- downloads and installs to the `$HOME` directory
-- updates `$PATH`, across all shell processes (for both interactive and batch sessions)
-- installs some powerful extensions:
+In addition, the script:
+- downloads and installs Miniconda to the `$HOME` directory
+- updates `$PATH`, exposing conda across all shell processes (for both interactive and batch sessions)
+- installs some useful extensions:
     - [`conda-build`](https://github.com/conda/conda-build)
     - [`anaconda-client`](https://github.com/Anaconda-Server/anaconda-client)
     
- 
-A majority of this (and additional) functionality is configurable, see the script source for options. :)
+See the script source for more options on configuration. :)
 
 ### install-conda-env.sh
 
-`install-conda-env.sh` contains logic for creating a conda environment and installing conda and/or pip packages. Sane defaults include:
+`install-conda-env.sh` contains logic for creating a conda environment and installing conda and/or pip packages. Defaults include:
 
 - if no conda environment name is specified, uses `root` (recommended).
 - detects if conda environment has already been created.
 - updates `/etc/profile` to activate the created environment at login (if needed)
 
+Note: When creating a conda environment using an environment.yml (set by `CONDA_ENV_YAML`), default configuration simply *updates the root environment* with dependencies specified in the file (ignoring the `name:` key). To set a specific name to the conda environment, users *must* set an additional env var, `CONDA_ENV_NAME`.
+
+
 ### Notes on running Python 3
 
 Starting with Python 3.3, hash randomization is enabled by default (see docs for [object.\__hash__](https://docs.python.org/3/reference/datamodel.html#object.__hash__)). Spark attempts to correct this by setting the `PYTHONHASHSEED` environment variable, but a [small bug in Spark](https://issues.apache.org/jira/browse/SPARK-13330) keeps the env var from propogating to all executors.
 
-The `boostrap-conda.sh` initialization action fixes this issue; users will not have to take any additional actions to use Python 3 on DataProc. Alternatively, users can pass the following `properties` argument when creating a DataProc cluster:
+The `boostrap-conda.sh` initialization action fixes this issue; users will not have to take any additional actions to use Python 3 on Dataproc. Alternatively, users can pass the following `properties` argument when creating a DataProc cluster:
 ```
 gcloud dataproc clusters create --properties spark:spark.executorEnv.PYTHONHASHSEED=0 ...
 ```
 Note that at this time Dataproc will *NOT* accept the property value when submitting a job; it must be passed when the cluster is created.
+
 
 ## Testing Installation
 

--- a/conda/README.MD
+++ b/conda/README.MD
@@ -21,7 +21,18 @@ gcloud dataproc clusters create my-dataproc-cluster \
     --master-machine-type=n1-standard-4
 ```
 
-Where `create-my-cluster.sh` could look like
+Where `create-my-cluster.sh` specifies a list of conda and / or pip packages to install:
+
+```
+# Install Miniconda / conda
+./dataproc-initialization-actions/conda/bootstrap-conda.sh
+# Update conda root environment with specific packages in pip and conda
+CONDA_PACKAGES='pandas dash scikit-learn'
+PIP_PACKAGES='plotly cufflinks'
+CONDA_PACKAGES=$CONDA_PACKAGES PIP_PACKAGES=$PIP_PACKAGES ./dataproc-initialization-actions/conda/install-conda-env.sh
+```
+
+Similarly, one can also specify a [conda environment yml file](https://github.com/conda/conda-env):
 
 ```
 #!/usr/bin/env bash
@@ -33,10 +44,11 @@ gsutil -m cp -r $CORAL_ENV_YAML_GSC_LOC $CONDA_ENV_YAML_PATH
 
 # Install Miniconda / conda
 ./dataproc-initialization-actions/conda/bootstrap-conda.sh
-# Create conda environment via conda yaml
+# Create / Update conda environment via conda yaml
 CONDA_ENV_YAML=$CONDA_ENV_YAML_PATH ./dataproc-initialization-actions/conda/install-conda-env.sh
 
 ```
+
 
 ## Details 
 

--- a/conda/README.MD
+++ b/conda/README.MD
@@ -62,7 +62,7 @@ See the script source for more options on configuration. :)
 - detects if conda environment has already been created.
 - updates `/etc/profile` to activate the created environment at login (if needed)
 
-Note: When creating a conda environment using an environment.yml (set by `CONDA_ENV_YAML`), default configuration simply *updates the root environment* with dependencies specified in the file (ignoring the `name:` key). To set a specific name to the conda environment, users *must* set an additional env var, `CONDA_ENV_NAME`.
+Note: When creating a conda environment using an environment.yml (via setting .yml path in `CONDA_ENV_YAML`), the `install-conda-env.sh` script simply *updates the **root** environment* with dependencies specified in the file (i.e., ignoring the `name:` key). This sidesteps some conda issues in `source activate`ing, while still providing all dependencies across the Dataproc cluster.
 
 
 ### Notes on running Python 3

--- a/conda/README.MD
+++ b/conda/README.MD
@@ -1,39 +1,69 @@
-# Miniconda (a Python distro and package manager, from Continuum Analytics)
+# Miniconda (a Python distro, along with package and environment manager, from Continuum Analytics)
 
-This folder contains initialization actions for getting up and going using [Miniconda](http://conda.pydata.org/miniconda.html). Miniconda is a shell script installer that contains both:
+## Overview
+
+This folder contains initialization actions for getting up and going using Miniconda, providing use of both:
  
-- [Anaconda](https://www.continuum.io/why-anaconda), a barebones version of a completely open (and legit) Python distro from Continuum Analytics, alongside,
-- [conda](http://conda.pydata.org/docs/), a completely open (and amazing) package manager.
+- [Minconda](http://conda.pydata.org/miniconda.html), a barebones version of [Anaconda](https://www.continuum.io/why-anaconda) of an open source (and totally legit) Python distro from Continuum Analytics, alongside,
+- [conda](http://conda.pydata.org/docs/), an open source (and amazing) package management system and environment management system.
+
+This allows Dataproc users to quickly and easily provision a Dataproc cluster leveraging conda's powerful package and environment management capabilities, including use of [conda environment definitions](https://github.com/conda/conda-env#environment-file-example).
+
+A real world example of this, to be used in a bash shell script, is as follows:
+
+gcloud dataproc clusters create my-dataproc-cluster \
+    --initialization-actions \
+        gs://dataproc-initialization-actions/jupyter/create-my-cluster.sh \
+    --bucket my-dataproc-bucket \
+    --num-workers 2 \
+    --worker-machine-type=n1-standard-4 \
+    --master-machine-type=n1-standard-4
+```
+
+Where `create-my-cluster.sh` could look like
+
+```
+#!/usr/bin/env bash
+
+CONDA_ENV_YAML_GSC_LOC="gs://my-bucket/path/to/conda-environment.yml"
+CONDA_ENV_YAML_PATH="/root/conda-environment.yml"
+echo "Downloading conda environment at $CONDA_ENV_YAML_GSC_LOC to $CONDA_ENV_YAML_PATH ... "
+gsutil -m cp -r $CORAL_ENV_YAML_GSC_LOC $CONDA_ENV_YAML_PATH
+
+# Install Miniconda / conda
+./dataproc-initialization-actions/conda/install-conda-env.sh
+# Install conda environment (provides dependencies)
+CONDA_ENV_YAML=$CONDA_ENV_YAML_PATH ./dataproc-initialization-actions/conda/install-conda-env.sh
+```
+
+## Details 
+
+### bootstrap-conda.sh
+
+`bootstrap-conda.sh` contains logic for quickly configuring and installing Miniconda across the dataproc cluster, with configuration exposed via sane environment variables with point-and-shoot defaults, including:
+
+- Miniconda version, defaults to Python 3 version, [`Miniconda3-latest-Linux-x86_64.sh`](https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh), however, users can easily config for targeted versions via th following env vars (see script source for all options):
+    - `MINICONDA_VARIANT`: the Python version can be `2` or `3`
+    - `MINICONDA_VER`: the Miniconda version (e.g., `4.0.5`)
  
-
-## bootstrap-conda.sh
-
-`bootstrap-conda.sh` contains logic for quickly configuring and installing Miniconda, with point-and-shoot defaults, including:
-
-- a choice of either Python 2 or Python 3 (defaults to Python 2; users can uncomment the appropriate lines near the top of `boostrap-conda.sh` to select Python 3)
-- the most recent Miniconda version (`3.18.3`)
 - downloads and installs to the `$HOME` directory
-- performs an md5sum hash check (failing quickly is always better)
-- updates current `$PATH` and subsequent definitions in `.bashrc`
-- updates `conda` and install `pip` in root environment (allowing pip installations)
+- updates `$PATH`, across all shell processes (for both interactive and batch sessions)
 - installs some powerful extensions:
-    - [`conda-env`](https://github.com/conda/conda-env)
     - [`conda-build`](https://github.com/conda/conda-build)
     - [`anaconda-client`](https://github.com/Anaconda-Server/anaconda-client)
     
  
-All of this can be changed with little effort.
+A majority of this (and additional) functionality is configurable, see the script source for options. :)
 
-## install-conda-env.sh
+### install-conda-env.sh
 
-`install-conda-env.sh` contains logic for creating a conda environment and installing conda (and pip) packages. Sane defaults include:
+`install-conda-env.sh` contains logic for creating a conda environment and installing conda and/or pip packages. Sane defaults include:
 
-- installs some common libraries (pandas, scikit-learn, bokeh, plotly, Jupyter) 
-- if no conda environment name is specified, uses `root`.
+- if no conda environment name is specified, uses `root` (recommended).
 - detects if conda environment has already been created.
-- updates `.bashrc` to activate the created environment at login
+- updates `/etc/profile` to activate the created environment at login (if needed)
 
-## Notes on running Python 3
+### Notes on running Python 3
 
 Starting with Python 3.3, hash randomization is enabled by default (see docs for [object.\__hash__](https://docs.python.org/3/reference/datamodel.html#object.__hash__)). Spark attempts to correct this by setting the `PYTHONHASHSEED` environment variable, but a [small bug in Spark](https://issues.apache.org/jira/browse/SPARK-13330) keeps the env var from propogating to all executors.
 
@@ -41,11 +71,11 @@ The `boostrap-conda.sh` initialization action fixes this issue; users will not h
 ```
 gcloud dataproc clusters create --properties spark:spark.executorEnv.PYTHONHASHSEED=0 ...
 ```
-Note that at this time Dataproc will NOT accept the property value when submitting a job; it must be passed when the cluster is created.
+Note that at this time Dataproc will *NOT* accept the property value when submitting a job; it must be passed when the cluster is created.
 
 ## Testing Installation
 
-A quick test to ensure installation of conda is working, we can submit jobs that collect distinct paths to the python distribution across all Spark executors. For both local (e.g., running form dataproc cluster master node) and remote (e.g. submitting a job via the dataproc API) jobs, the result should be a list with a single path: `['/usr/local/bin/miniconda/bin/python']`. See more
+A quick test to ensure a correct installation of conda, we can submit jobs that collect distinct paths to the Python distribution across all Spark executors. For both local (e.g., running form dataproc cluster master node) and remote (e.g. submitting a job via the dataproc API) jobs, the result should be a list with a single path: `['/usr/local/bin/miniconda/bin/python']`. For example
 
 
 ### Local Job Test

--- a/conda/bootstrap-conda.sh
+++ b/conda/bootstrap-conda.sh
@@ -16,12 +16,13 @@ CONDA_INSTALL_PATH="/usr/local/bin/miniconda"
 OS_TYPE="Linux-x86_64.sh"
 # specify Miniconda release
 MINICONDA_VER='3.19.0'
-## Python 2 or 3?
-MINICONDA_VARIANT="Miniconda2"  #for Python 2.7.x
-expectedHash="628f158791daf7d634fb6894045a6be1"
-#MINICONDA_VARIANT="Miniconda3"  #for Python 3.5.x
-#expectedHash="b834b525d3f42add8f2af0153d13f498"
-
+##
+if [[ ! -v MINICONDA_VARIANT ]]; then
+    #MINICONDA_VARIANT="Miniconda2"  #for Python 2.7.x
+    #expectedHash="628f158791daf7d634fb6894045a6be1"
+    MINICONDA_VARIANT="Miniconda3"  #for Python 3.5.x
+    expectedHash="b834b525d3f42add8f2af0153d13f498"
+fi
 ## 0. Compute Miniconda version
 miniconda="$MINICONDA_VARIANT-$MINICONDA_VER-$OS_TYPE"
 

--- a/conda/install-conda-env.sh
+++ b/conda/install-conda-env.sh
@@ -25,7 +25,20 @@ conda update --all
 # For Dataproc provisioning, we should install to root conda env.
 if [[ -v CONDA_ENV_YAML ]]; then
     #CONDA_ENV_NAME=$(grep 'name: ' $CONDA_ENV_YAML | awk '{print $2}')
-    conda env update --name=$CONDA_ENV_NAME --file=$CONDA_ENV_YAML #coral/env/env_coral__core.yml
+    # if conda environment name is root, we *update* the root environment with env yaml
+    if [[ $CONDA_ENV_NAME == 'root' ]]
+        then
+        echo "Updating root environment with file $CONDA_ENV_YAML"
+        conda env update --name=$CONDA_ENV_NAME --file=$CONDA_ENV_YAML
+        echo "Root environment updated..."
+
+    # otherwise, perform a typical environment creation via install
+    else
+        echo "Creating $CONDA_ENV_NAME environment with file $CONDA_ENV_YAML"
+        conda env create --name=$CONDA_ENV_NAME --file=$CONDA_ENV_YAML
+        echo "conda environment $CONDA_ENV_NAME created..."
+
+    fi
 fi
 
 # 1. Or create conda env manually.

--- a/conda/install-conda-env.sh
+++ b/conda/install-conda-env.sh
@@ -15,8 +15,16 @@ echo "echo \$CONDA_BIN_PATH: $CONDA_BIN_PATH"
 if [[ ! -v CONDA_ENV_NAME ]]; then
     echo "No conda environment name specified, setting to 'root' env..."
     CONDA_ENV_NAME='root'
+# Force conda env name to be set to root for now, until a braver soul manages the complexity of environment activation
+# across the cluster.
 else
-    echo "conda environment $CONDA_ENV_NAME set!"
+    echo "conda environment name is set to $CONDA_ENV_NAME"
+    if [[ ! $CONDA_ENV_NAME == 'root' ]]
+        then
+        echo "Custom conda environment names not supported at this time."
+        echo "Force setting conda env to 'root'..."
+    fi
+    CONDA_ENV_NAME='root'
 fi
 
 conda update --all
@@ -31,13 +39,11 @@ if [[ -v CONDA_ENV_YAML ]]; then
         echo "Updating root environment with file $CONDA_ENV_YAML"
         conda env update --name=$CONDA_ENV_NAME --file=$CONDA_ENV_YAML
         echo "Root environment updated..."
-
     # otherwise, perform a typical environment creation via install
     else
         echo "Creating $CONDA_ENV_NAME environment with file $CONDA_ENV_YAML"
         conda env create --name=$CONDA_ENV_NAME --file=$CONDA_ENV_YAML
         echo "conda environment $CONDA_ENV_NAME created..."
-
     fi
 fi
 

--- a/jupyter/README.MD
+++ b/jupyter/README.MD
@@ -1,6 +1,6 @@
 # Jupyter Notebook
 
-This folder contains the initialization action `jupyter.sh` to quickly setup and launch [Jupyter Notebook](http://jupyter.org/), (the successor of IPython notebook) and a script to be run on the user's local machine to access the Jupyter notebook server.
+This folder contains initialization action to quickly setup and launch [Jupyter Notebook](http://jupyter.org/), (the successor of IPython notebook) along with [notebook extensions](https://github.com/ipython-contrib/IPython-notebook-extensions), and [RISE](https://github.com/damianavila/RISE). Jupyter is configured to run on port `8123` on the master node in the Dataproc cluster. To connect to the Jupyter Notebook web interface, you can simply configure and launch using `launch-jupyter-interface.sh` from your local machine.
 
 A real-world example of how to use this from within a bash script, using the default dataproc-initialization-actions repo/branch:
 
@@ -24,7 +24,7 @@ gcloud dataproc clusters create my-dataproc-cluster \
 - clones the dataproc-initialization-actions git repo/branch specified in the `INIT_ACTIONS_REPO` and `INIT_ACTIONS_BRANCH` metadata keys
   - if these two metadata keys are not set during cluster creation, the default values `https://github.com/GoogleCloudPlatform/dataproc-initialization-actions.git` and `master` are used
   - this is provided so that a fork/branch of the main repo can easily be used, eg, during development
-- executes `conda/bootstrap-conda.sh` and `conda/install-conda.sh` from said repo/branch to ensure `miniconda` is available
+- executes `conda/bootstrap-conda.sh` from said repo/branch to ensure `miniconda` is available
 - executes `jupyter/internal/setup-jupyter-kernel.sh` and `jupyter/internal/launch-jupyter-kernel.sh` from said repo/branch
   - configures `jupyter` to use the *PySpark* kernel found at `jupyter/kernels/pyspark/kernel.json`
   - configures `jupyter` to listen on the port specified by the metadata key `JUPYTER_PORT`, with a default value of `8123`
@@ -43,3 +43,4 @@ gcloud dataproc clusters create my-dataproc-cluster \
 - launch a Chrome instance that uses this ssh tunnel and references the Jupyter port.
 
 **NOTE**: to be run from a local machine
+ 

--- a/jupyter/README.MD
+++ b/jupyter/README.MD
@@ -1,6 +1,6 @@
 # Jupyter Notebook
 
-This folder contains initialization action to quickly setup and launch [Jupyter Notebook](http://jupyter.org/), (the successor of IPython notebook) along with [notebook extensions](https://github.com/ipython-contrib/IPython-notebook-extensions), and [RISE](https://github.com/damianavila/RISE). Jupyter is configured to run on port `8123` on the master node in the Dataproc cluster. To connect to the Jupyter Notebook web interface, you can simply configure and launch using `launch-jupyter-interface.sh` from your local machine.
+This folder contains the initialization action `jupyter.sh` to quickly setup and launch [Jupyter Notebook](http://jupyter.org/), (the successor of IPython notebook) and a script to be run on the user's local machine to access the Jupyter notebook server.
 
 A real-world example of how to use this from within a bash script, using the default dataproc-initialization-actions repo/branch:
 

--- a/jupyter/internal/bootstrap-jupyter-ext.sh
+++ b/jupyter/internal/bootstrap-jupyter-ext.sh
@@ -13,7 +13,8 @@ sudo apt-get install -y git
 # > Command failed: /bin/bash -x -e
 # > /home/vagrant/miniconda-3.18.3/conda-bld/work/conda_build.sh
 # If directory doesn't exist, attempt to create it.
-if [ ! -d "~/.local/share/jupyter/" ]; then
+if [[ ! -d "~/.local/share/jupyter/" ]]
+then
   echo "~/.local/share/jupyter/ directory does not exist, creating..."
   mkdir -p ~/.local/share/jupyter/
   echo "~/.local/share/jupyter/ directory created, continuing..."
@@ -21,7 +22,8 @@ fi
 
 # 1. Install IPyNB extensions:
 nbext_path='IPython-notebook-extensions'
-if [[ ! -d $nbext_path ]]; then
+if [[ ! -d $nbext_path ]]
+then
     echo "Installing $nbext_path"
     git clone https://github.com/ipython-contrib/IPython-notebook-extensions.git
     conda build IPython-notebook-extensions
@@ -32,7 +34,8 @@ fi
 
 # 2. Install RISE (http://github.com/damianavila/RISE)
 rise_path='RISE'
-if [[ ! -d $rise_path ]]; then
+if [[ ! -d $rise_path ]]
+then
     echo "Installing $rise_path"
     git clone https://github.com/damianavila/RISE.git
     cd RISE && python setup.py install

--- a/jupyter/internal/setup-jupyter-kernel.sh
+++ b/jupyter/internal/setup-jupyter-kernel.sh
@@ -8,7 +8,7 @@ source "$DIR/../../util/utils.sh"
 ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 JUPYTER_KERNEL_DIR="/dataproc-initialization-actions/jupyter/kernels/pyspark"
 JUPYTER_NOTEBOOK_DIR="/root/notebooks"
-JUPYTER_PORT=$(/usr/share/google/get_metadata_value attributes/JUPYTER_PORT || true)
+JUPYTER_PORT=$(/usr/share/google/get_metadata_value attributes/JUPYTER_PORT)
 [[ ! $JUPYTER_PORT =~ ^[0-9]+$ ]] && JUPYTER_PORT=8123
 JUPYTER_IP=*
 

--- a/jupyter/kernels/pyspark/kernel.json
+++ b/jupyter/kernels/pyspark/kernel.json
@@ -7,7 +7,7 @@
     "SPARK_HOME": "/usr/lib/spark/",
     "PYTHONPATH": "/usr/lib/spark/python/:/usr/lib/spark/python/lib/py4j-0.9-src.zip",
     "PYTHONSTARTUP": "/usr/lib/spark/python/pyspark/shell.py",
-    "PYSPARK_SUBMIT_ARGS": "--master yarn --deploy-mode client pyspark-shell"
+    "PYSPARK_SUBMIT_ARGS": "--master yarn --deploy-mode client --packages com.databricks:spark-csv_2.10:1.3.0 pyspark-shell"
  }
 }
 

--- a/jupyter/launch-jupyter-interface.sh
+++ b/jupyter/launch-jupyter-interface.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -e
 
 DIR="${BASH_SOURCE%/*}"

--- a/util/utils.sh
+++ b/util/utils.sh
@@ -16,6 +16,6 @@ get_metadata_property () {
     [[ -z $1 ]] && throw "missing function param for DATAPROC_CLUSTER_NAME" || DATAPROC_CLUSTER_NAME=$1
     [[ -z $2 ]] && throw "missing function param for METADATA_KEY" || METADATA_KEY=$2
     # Get $DATAPROC_CLUSTER_NAME metadata value for key $METADATA_KEY...
-    gcloud dataproc clusters describe $DATAPROC_CLUSTER_NAME | python -c "import sys,yaml; cluster = yaml.load(sys.stdin); print cluster['config']['gceClusterConfig']['metadata']['$METADATA_KEY']"
+    gcloud dataproc clusters describe $DATAPROC_CLUSTER_NAME | python -c "import sys,yaml; cluster = yaml.load(sys.stdin); print(cluster['config']['gceClusterConfig']['metadata']['$METADATA_KEY'])"
 }
 


### PR DESCRIPTION
This is a substantial refactor of the conda init action:
- exposes environment variables in `bootstrap-conda.sh` and `install-conda-env.sh`, allowing more configuration of both
- allows for use of conda environment yaml files for specifying dependencies
- updates documentation about it all, with examples.