### PR TITLE
Fix failure when JUPYTER_PORT not specified

### DIFF
--- a/conda/bootstrap-conda.sh
+++ b/conda/bootstrap-conda.sh
@@ -6,6 +6,7 @@ set -e
 # Run on BOTH 'Master' and 'Worker' nodes
 #ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 #if [[ "${ROLE}" == 'Master' ]]; then
+MINICONDA_VARIANT=$(/usr/share/google/get_metadata_value attributes/MINICONDA_VARIANT || true)
 
 if [[ ! -v CONDA_INSTALL_PATH ]]; then
     echo "CONDA_INSTALL_PATH not set, setting ..."

--- a/jupyter/internal/setup-jupyter-kernel.sh
+++ b/jupyter/internal/setup-jupyter-kernel.sh
@@ -8,7 +8,7 @@ source "$DIR/../../util/utils.sh"
 ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 JUPYTER_KERNEL_DIR="/dataproc-initialization-actions/jupyter/kernels/pyspark"
 JUPYTER_NOTEBOOK_DIR="/root/notebooks"
-JUPYTER_PORT=$(/usr/share/google/get_metadata_value attributes/JUPYTER_PORT)
+JUPYTER_PORT=$(/usr/share/google/get_metadata_value attributes/JUPYTER_PORT || true)
 [[ ! $JUPYTER_PORT =~ ^[0-9]+$ ]] && JUPYTER_PORT=8123
 JUPYTER_IP=*
 


### PR DESCRIPTION
additionally, allow MINICONDA_VARIANT to be defined by GCE metadata.