### PR TITLE
Fix apt source urls

### DIFF
--- a/ganglia/ganglia.sh
+++ b/ganglia/ganglia.sh
@@ -15,7 +15,7 @@
 
 set -x -e
 
-apt-get install -y ganglia-monitor
+apt-get update && apt-get install -y ganglia-monitor
 
 MASTER=$(/usr/share/google/get_metadata_value attributes/dataproc-master)
 


### PR DESCRIPTION
Perform `apt-get update` before installing ganglia packages to make sure that the repository urls are correct.