### PR TITLE
Fix stackdriver installation instructions.

### DIFF
--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -16,18 +16,39 @@ Once you have configured a copy of this script, you can use this initialization 
 with the Stackdriver agent installed by:
 
 1. Uploading a copy of the initialization action (`stackdriver.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-1. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>` and specify the initialization action stored in `<GCS_BUCKET>`.
+1. Using the `gcloud` command to create a new cluster with this initialization action. You must add the [requisite stackdriver monitoring scope(s)](https://cloud.google.com/monitoring/api/authentication#cloud_monitoring_scopes). The following command will create a new cluster named `<CLUSTER_NAME>` and specify the initialization action stored in `<GCS_BUCKET>`.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://<GCS_BUCKET>/stackdriver.sh
+        --initialization-actions gs://<GCS_BUCKET>/stackdriver.sh \
+        --scopes https://www.googleapis.com/auth/monitoring.write
     ```
 1. Once the cluster is online, Stackdriver should automatically start capturing data from your cluster. You can visit
 the [Stackdriver interface](https://app.google.stackdriver.com/) to view the metrics.
 
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 
+## Useful Tips
+
+To better identify your cluster in a Stackdriver dashboard, you'll likely want to append a unique tag when creating
+your cluster:
+
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+        --initialization-actions gs://<GCS_BUCKET>/stackdriver.sh \
+        --scopes https://www.googleapis.com/auth/monitoring.write \
+        --tags my-dataproc-cluster-20160901-1518
+
+This way, even if you reuse your `<CLUSTER_NAME>` in the future, you can easily disambiguate which incarnation
+of the cluster you want to look at in your Stackdriver dashboards. For convenience, you may also want to use
+to Google-hosted copy of the dataproc-initialization-actions repo; for example, once you've enabled the Stackdriver
+APIs you can simply copy/paste:
+
+    gcloud dataproc clusters create ${USER}-dataproc-cluster \
+        --initialization-actions gs://dataproc-initialization-actions/stackdriver/stackdriver.sh \
+        --scopes https://www.googleapis.com/auth/monitoring.write \
+        --tags ${USER}-dataproc-cluster-$(date +%Y%m%d-%H%M%S)
+
 ## Important notes
-* If you do not create a group in Stackdriver with the same prefix as your cluster name, Stackdriver will not
-automatically pick up data from your cluster.
+* If you do not create a group in Stackdriver with the same prefix as your cluster name or using the unique tag you
+provided at cluster-creation time, Stackdriver will not automatically pick up data from your cluster.
 * Ensure you have reviewed the [pricing for Stackdriver](https://cloudplatform.googleblog.com/2016/06/announcing-pricing-for-Google-Stackdriver.html)


### PR DESCRIPTION
Add a note to include required stackdriver scopes with a link to further
stackdriver monitoring documentation; add suggestion to use unique tags to
more easily identify clusters for stackdriver dashboard creation.