### PR TITLE
Add a new post-init helper script.

### DIFF
--- a/post-init/README.md
+++ b/post-init/README.md
@@ -1,0 +1,84 @@
+# On-boot commands
+
+This initialization action can be used as either an initialization action or as a startup-script,
+with the latter enabling support for commands which need to be re-run on reboot. This
+initialization action adds polling for the cluster itself to be fully healthy before issuing
+a command, effectively allowing "post-initiailization" actions which can include further setup
+or submitting a job.
+
+## Using this initialization action
+
+For now, the script relies on polling the Dataproc API to determine an authoritative state
+of cluster health on startup, so requires the `--scopes cloud-platform` flag; do not use
+this initialization action if you are unwilling to grant your Dataproc clusters' service
+account with the `cloud-platform` scope.
+
+The initialization action is designed to log the output of your post-init command into
+`/var/log/master-post-init.log`; when debugging, if it doesn't behave as expected, SSH
+into the master node and view that logfile for more details. If it doesn't exist, then
+you can likely find additional details in the initialization-action or startup-script
+logs also in the `/var/log` directory.
+
+## Examples
+
+### Submit a single job with cluster and turn off cluster on completion
+
+Simply modify the `POST_INIT_COMMAND` to whatever actual job submission command you want to run:
+
+    export CLUSTER_NAME=${USER}-shortlived-cluster
+    export POST_INIT_COMMAND=" \
+        gcloud dataproc jobs submit hadoop \
+            --cluster ${CLUSTER_NAME} \
+            --jar file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar \
+            teragen 10000 /tmp/teragen; \
+        gcloud dataproc clusters delete -q ${CLUSTER_NAME}"
+    gcloud dataproc clusters create ${CLUSTER_NAME} \
+        --scopes cloud-platform \
+        --initialization-actions gs://dataproc-initialization-actions/post-init/master-post-init.sh \
+        --metadata post-init-command="${POST_INIT_COMMAND}"
+
+
+### Submit a single job with cluster and turn off cluster only if job succeeds
+
+If you replace the semicolon with "&&" before the `gcloud dataproc clusters delete` call, then
+the cluster will only be deleted if the job was successful:
+
+    export CLUSTER_NAME=${USER}-shortlived-cluster
+    export POST_INIT_COMMAND=" \
+        gcloud dataproc jobs submit hadoop \
+            --cluster ${CLUSTER_NAME} \
+            --jar file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar \
+            teragen 10000 /tmp/teragen && \
+        gcloud dataproc clusters delete -q ${CLUSTER_NAME}"
+    gcloud dataproc clusters create ${CLUSTER_NAME} \
+        --scopes cloud-platform \
+        --initialization-actions gs://dataproc-initialization-actions/post-init/master-post-init.sh \
+        --metadata post-init-command="${POST_INIT_COMMAND}"
+
+## Create a cluster which automatically resubmits a job on restart or job termination (e.g. for streaming processing)
+
+If you supply this init action as a GCE "startup-script" instead of as an init action, then it
+will be run on every (re)boot. This can be leveraged to set up reliable "long-lived" jobs.
+
+Note that individual job incarnations will always be vulnerable to at least some failure mode
+by nature (master might suffer unexpected hardware reboot, AppMaster might crash, etc). So,
+a "long-lived" job generally won't be a single job incarnation, but rather just ongoing
+"resubmission" of a job with the same params on failure. Your application layer is then
+responsible for recovering any ongoing state, if applicable.
+
+Dataproc by default will forcibly terminate the YARN applications it detects which appear
+to be orphaned from a failed job driver/client program; this makes it safe to resubmit
+the job on reboot without manually tracking down orphaned YARN applications which may be
+consuming resources for the job that you want to resubmit.
+
+    export CLUSTER_NAME=${USER}-longrunning-job-cluster
+    export POST_INIT_COMMAND=" \
+        while true; do \
+          gcloud dataproc jobs submit spark \
+              --cluster ${CLUSTER_NAME} \
+              --jar gs://${BUCKET}/my-longlived-job.jar foo args; \
+        done"
+    gcloud dataproc clusters create ${CLUSTER_NAME} \
+        --scopes cloud-platform \
+        --metadata startup-script-url=gs://dataproc-initialization-actions/post-init/master-post-init.sh,post-init-command="${POST_INIT_COMMAND}"
+

--- a/post-init/master-post-init.sh
+++ b/post-init/master-post-init.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Can be used either under --metadata startup-script-url=... or with
+# --initialization-actions to invoke commands (like submitting a job)
+# after cluster becomes initially healthy and then on every master
+# reboot or a single time on cluster deployment, respectively.
+#
+# Examples:
+#   Submit a single job with cluster and turn off cluster on completion:
+#
+#     gcloud dataproc clusters create ${CLUSTER_NAME} --scopes cloud-platform --initialization-actions gs://${BUCKET}/master-post-init.sh --metadata post-init-command="gcloud dataproc jobs submit hadoop --cluster ${CLUSTER_NAME} --jar file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar teragen 10000 /tmp/teragen; gcloud dataproc clusters delete -q ${CLUSTER_NAME}"
+#
+#   Create a cluster which runs a "forever-running" job, resubmitting on reboot
+#   or if the job terminates for any reason:
+#
+#     gcloud dataproc clusters create ${CLUSTER_NAME} --scopes cloud-platform --metadata startup-script-url=gs://${BUCKET}/master-post-init.sh,post-init-command="while true; do gcloud dataproc jobs submit spark --cluster ${CLUSTER_NAME} --jar gs://${BUCKET}/my-longlived-job.jar foo args; done"
+
+METADATA_ROOT='http://metadata/computeMetadata/v1/instance/attributes'
+
+# Only run on master. If you want to run on all nodes instead, then simply
+# remove these lines which exit for non-master nodes.
+ROLE=$(curl -f -s -H Metadata-Flavor:Google ${METADATA_ROOT}/dataproc-role)
+if [[ "${ROLE}" != 'Master' ]]; then
+  exit 0
+fi
+
+CLUSTER_NAME=$(curl -f -s -H Metadata-Flavor:Google \
+    ${METADATA_ROOT}/dataproc-cluster-name)
+
+# Fetch the actual command we want to run once the cluster is healthy.
+# The command is specified with the 'post-init-command' key.
+POST_INIT_COMMAND=$(curl -f -s -H Metadata-Flavor:Google \
+    ${METADATA_ROOT}/post-init-command)
+
+if [ -z ${POST_INIT_COMMAND} ]; then
+  echo "Failed to find metadata key 'post-init-command'"
+  exit 1
+fi
+
+# We must put the bulk of the login in a separate helper script so that we can
+# 'nohup' it.
+cat << EOF > /usr/local/bin/await_cluster_and_run_command.sh
+#!/bin/bash
+
+# Helper to get current cluster state.
+function get_cluster_state() {
+  echo \$(gcloud dataproc clusters describe ${CLUSTER_NAME} | \
+      grep -A 1 "^status:" | grep "state:" | cut -d ':' -f 2)
+}
+
+# Helper which waits for RUNNING state before issuing the command.
+function await_and_submit() {
+  local cluster_state=\$(get_cluster_state)
+  echo "Current cluster state: \${cluster_state}"
+  while [[ "\${cluster_state}" != 'RUNNING' ]]; do
+    echo "Sleeping to await cluster health..."
+    sleep 5
+    local cluster_state=\$(get_cluster_state)
+    if [[ "\${cluster_state}" == 'ERROR' ]]; then
+      echo "Giving up due to cluster state '\${cluster_state}'"
+      exit 1
+    fi
+  done
+
+  ${POST_INIT_COMMAND}
+}
+
+await_and_submit
+EOF
+
+chmod 750 /usr/local/bin/await_cluster_and_run_command.sh
+
+# Uncomment this following line and comment out the line after it to throw away
+# the stdout/stderr of the command instead of logging it.
+#nohup /usr/local/bin/await_cluster_and_run_command.sh &>> /dev/null &
+nohup /usr/local/bin/await_cluster_and_run_command.sh &>> \
+    /var/log/master-post-init.log &


### PR DESCRIPTION
This initialization action can be used as either an initialization action or as a startup-script,
with the latter enabling support for commands which need to be re-run on reboot. This
initialization action adds polling for the cluster itself to be fully healthy before issuing
a command, effectively allowing "post-initiailization" actions which can include further setup
or submitting a job.