### PR TITLE
fix URI space issue

### DIFF
--- a/flink/flink.sh
+++ b/flink/flink.sh
@@ -33,9 +33,9 @@ FLINK_VERSION="1.0.3"
 
 # Location of the FLink binary archive
 CONCAT_HADOOP_VERSION=$(echo $HADOOP_VERSION | sed 's/\.//g')
-FLINK_TARBALL_URI="http://www-us.apache.org/dist/flink/flink-${FLINK_VERSION}\
-	/flink-${FLINK_VERSION}-bin-hadoop${CONCAT_HADOOP_VERSION}-\
-	scala_${SCALA_VERSION}.tgz"
+FLINK_HADOOP_URI="flink-${FLINK_VERSION}-bin-hadoop${CONCAT_HADOOP_VERSION}"
+SCALA_URI="scala_${SCALA_VERSION}.tgz"
+FLINK_TARBALL_URI="http://www-us.apache.org/dist/flink/flink-${FLINK_VERSION}/${FLINK_HADOOP_URI}-${SCALA_URI}"
 
 # Install directories for Flink and Hadoop
 FLINK_INSTALL_DIR='/usr/lib/flink'

--- a/flink/flink.sh
+++ b/flink/flink.sh
@@ -73,8 +73,7 @@ FLINK_TASKMANAGER_MEMORY=$(python -c \
     "print int(${TOTAL_MEM} * ${FLINK_TASKMANAGER_MEMORY_FRACTION})")
 
 # Install Flink and tidy things up
-FLINK_TARBALL_NAME="flink-${FLINK_VERSION}-bin-hadoop${CONCAT_HADOOP_VERSION}-\
-	scala_${SCALA_VERSION}.tgz"
+FLINK_TARBALL_NAME="flink-${FLINK_VERSION}-bin-hadoop${CONCAT_HADOOP_VERSION}-scala_${SCALA_VERSION}.tgz"
 FLINK_EXTRACT_DIRECTORY="flink-${FLINK_VERSION}"
 mkdir ${FLINK_INSTALL_DIR}
 cd ${FLINK_INSTALL_DIR}
@@ -97,5 +96,4 @@ fs.hdfs.hadoopconf: ${HADOOP_CONF_DIR}
 EOF
 
 # Start a Flink YARN session
-HADOOP_CONF_DIR=/etc/hadoop/conf ./bin/yarn-session.sh -n \
-	${FLINK_TASKMANAGER_SLOTS} --detached
+HADOOP_CONF_DIR=/etc/hadoop/conf ./bin/yarn-session.sh -n ${FLINK_TASKMANAGER_SLOTS} --detached

--- a/flink/flink.sh
+++ b/flink/flink.sh
@@ -29,13 +29,15 @@ SCALA_VERSION="2.10"
 # Hadoop version on the cluster see the following side for details
 HADOOP_VERSION="2.7"
 # Flink version to be installed on the cluster
-FLINK_VERSION="1.0.3"
+FLINK_VERSION="1.1.4"
 
 # Location of the FLink binary archive
 CONCAT_HADOOP_VERSION=$(echo $HADOOP_VERSION | sed 's/\.//g')
 FLINK_HADOOP_URI="flink-${FLINK_VERSION}-bin-hadoop${CONCAT_HADOOP_VERSION}"
 SCALA_URI="scala_${SCALA_VERSION}.tgz"
 FLINK_TARBALL_URI="http://www-us.apache.org/dist/flink/flink-${FLINK_VERSION}/${FLINK_HADOOP_URI}-${SCALA_URI}"
+
+echo $FLINK_TARBALL_URI
 
 # Install directories for Flink and Hadoop
 FLINK_INSTALL_DIR='/usr/lib/flink'


### PR DESCRIPTION
The space in URI will cause break.

`--2016-12-23 09:31:27--  http://www-us.apache.org/dist/flink/flink-1.0.3
Resolving www-us.apache.org (www-us.apache.org)... 140.211.11.105
Connecting to www-us.apache.org (www-us.apache.org)|140.211.11.105|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: http://www-us.apache.org/dist/flink/flink-1.0.3/ [following]
--2016-12-23 09:31:27--  http://www-us.apache.org/dist/flink/flink-1.0.3/
Reusing existing connection to www-us.apache.org:80.
HTTP request sent, awaiting response... 200 OK
Length: 7179 (7.0K) [text/html]
Saving to: ‘flink-1.0.3’

     0K .......                                               100%  858M=0s

2016-12-23 09:31:27 (858 MB/s) - ‘flink-1.0.3’ saved [7179/7179]

/flink-1.0.3-bin-hadoop27-: Scheme missing.
--2016-12-23 09:31:27--  http://scala_2.10.tgz/
Resolving scala_2.10.tgz (scala_2.10.tgz)... failed: Name or service not known.
wget: unable to resolve host address ‘scala_2.10.tgz’
FINISHED --2016-12-23 09:31:27--
Total wall clock time: 0.2s
Downloaded: 1 files, 7.0K in 0s (858 MB/s)
tar (child): flink-1.0.3-bin-hadoop27-: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
mv: cannot stat ‘flink-1.0.3/*’: Not a directory
rm: cannot remove ‘flink-1.0.3-bin-hadoop27-’: No such file or directory
rm: cannot remove ‘scala_2.10.tgz’: No such file or directory
rmdir: failed to remove ‘flink-1.0.3’: Not a directory
/etc/google-dataproc/startup-scripts/dataproc-initialization-script-0: line 88: /usr/lib/flink/conf/flink-conf.yaml: No such file or directory
/etc/google-dataproc/startup-scripts/dataproc-initialization-script-0: line 100: ./bin/yarn-session.sh: No such file or directory`