### PR TITLE
Fix flink init action.

### DIFF
--- a/flink/flink.sh
+++ b/flink/flink.sh
@@ -34,12 +34,11 @@ readonly FLINK_NETWORK_NUM_BUFFERS=2048
 
 # Heap memory used by the job manager (master) determined by the physical (free) memory of the server
 # Flink config entry: jobmanager.heap.mb
-# TODO: Consider tuning this.
-readonly FLINK_JOBMANAGER_MEMORY_FRACTION='0.8'
+readonly FLINK_JOBMANAGER_MEMORY_FRACTION='1.0'
 
 # Heap memory used by the task managers (slaves) determined by the physical (free) memory of the servers
 # Flink config entry: taskmanager.heap.mb
-readonly FLINK_TASKMANAGER_MEMORY_FRACTION='0.8'
+readonly FLINK_TASKMANAGER_MEMORY_FRACTION='1.0'
 
 # Set this to true to start a flink yarn session at initialization time.
 readonly START_FLINK_YARN_SESSION="true"

--- a/flink/flink.sh
+++ b/flink/flink.sh
@@ -66,7 +66,6 @@ function configure_flink() {
       "print ${num_workers} * ${flink_taskmanager_slots}")
 
   # Get worker memory from yarn config.
-  # NOTE: This should really be the memory per worker (rather than per master).
   local worker_total_mem="$(hdfs getconf \
     -confKey yarn.nodemanager.resource.memory-mb)"
   local flink_jobmanager_memory=$(python -c \

--- a/flink/flink.sh
+++ b/flink/flink.sh
@@ -34,6 +34,7 @@ readonly FLINK_NETWORK_NUM_BUFFERS=2048
 
 # Heap memory used by the job manager (master) determined by the physical (free) memory of the server
 # Flink config entry: jobmanager.heap.mb
+# TODO: Consider tuning this.
 readonly FLINK_JOBMANAGER_MEMORY_FRACTION='0.8'
 
 # Heap memory used by the task managers (slaves) determined by the physical (free) memory of the servers
@@ -55,7 +56,7 @@ function configure_flink() {
   local flink_parallelism=$(python -c \
       "print ${num_workers} * ${flink_taskmanager_slots}")
 
-  # Calculate the memory allocations, MB, using 'free -m'. Floor to nearest MB.
+  # Get worker memory from yarn config.
   # NOTE: This should really be the memory per worker (rather than per master).
   local worker_total_mem="$(hdfs getconf \
     -confKey yarn.nodemanager.resource.memory-mb)"

--- a/flink/flink.sh
+++ b/flink/flink.sh
@@ -22,80 +22,75 @@
 # Cloud Dataproc Image Version informayion:
 # https://cloud.google.com/dataproc/concepts/dataproc-versions
 
-# Number of worker nodes in your cluster
-NUM_WORKERS=$(/usr/share/google/get_metadata_value attributes/dataproc-worker-count)
-# Scala version on the cluster see the following side for details
-SCALA_VERSION="2.10"
-# Hadoop version on the cluster see the following side for details
-HADOOP_VERSION="2.7"
-# Flink version to be installed on the cluster
-FLINK_VERSION="1.0.3"
-
-# Location of the FLink binary archive
-CONCAT_HADOOP_VERSION=$(echo $HADOOP_VERSION | sed 's/\.//g')
-FLINK_TARBALL_URI="http://www-us.apache.org/dist/flink/flink-${FLINK_VERSION}\
-	/flink-${FLINK_VERSION}-bin-hadoop${CONCAT_HADOOP_VERSION}-\
-	scala_${SCALA_VERSION}.tgz"
+set -x -e
 
 # Install directories for Flink and Hadoop
-FLINK_INSTALL_DIR='/usr/lib/flink'
-HADOOP_CONF_DIR='/etc/hadoop/conf'
-
-# Default parallelism (number of concurrent actions per task)
-# If set to 'auto', this will be determined automatically
-# Flink config entry: parallelism.default
-FLINK_PARALLELISM='auto'
+readonly FLINK_INSTALL_DIR='/usr/lib/flink'
+readonly HADOOP_CONF_DIR='/etc/hadoop/conf'
 
 # The number of buffers for the network stack
 # Flink config entry: taskmanager.network.numberOfBuffers
-FLINK_NETWORK_NUM_BUFFERS=2048
+readonly FLINK_NETWORK_NUM_BUFFERS=2048
 
 # Heap memory used by the job manager (master) determined by the physical (free) memory of the server
 # Flink config entry: jobmanager.heap.mb
-FLINK_JOBMANAGER_MEMORY_FRACTION='0.8'
+readonly FLINK_JOBMANAGER_MEMORY_FRACTION='0.8'
 
 # Heap memory used by the task managers (slaves) determined by the physical (free) memory of the servers
 # Flink config entry: taskmanager.heap.mb
-FLINK_TASKMANAGER_MEMORY_FRACTION='0.8'
+readonly FLINK_TASKMANAGER_MEMORY_FRACTION='0.8'
+
+# Set this to true to start a flink yarn session at initialization time.
+readonly START_FLINK_YARN_SESSION="true"
+
+function configure_flink() {
+# Number of worker nodes in your cluster
+local num_workers=$(/usr/share/google/get_metadata_value attributes/dataproc-worker-count)
 
 # Determine the number of task slots
-FLINK_TASKMANAGER_SLOTS=`grep -c processor /proc/cpuinfo`
+local flink_taskmanager_slots=`grep -c processor /proc/cpuinfo`
 
 # Determine the default parallelism
-FLINK_PARALLELISM=$(python -c \
-    "print ${NUM_WORKERS} * ${FLINK_TASKMANAGER_SLOTS}")
+local flink_parallelism=$(python -c \
+    "print ${num_workers} * ${flink_taskmanager_slots}")
 
 # Calculate the memory allocations, MB, using 'free -m'. Floor to nearest MB.
-TOTAL_MEM=$(free -m | awk '/^Mem:/{print $2}')
-FLINK_JOBMANAGER_MEMORY=$(python -c \
-    "print int(${TOTAL_MEM} * ${FLINK_JOBMANAGER_MEMORY_FRACTION})")
-FLINK_TASKMANAGER_MEMORY=$(python -c \
-    "print int(${TOTAL_MEM} * ${FLINK_TASKMANAGER_MEMORY_FRACTION})")
-
-# Install Flink and tidy things up
-FLINK_TARBALL_NAME="flink-${FLINK_VERSION}-bin-hadoop${CONCAT_HADOOP_VERSION}-\
-	scala_${SCALA_VERSION}.tgz"
-FLINK_EXTRACT_DIRECTORY="flink-${FLINK_VERSION}"
-mkdir ${FLINK_INSTALL_DIR}
-cd ${FLINK_INSTALL_DIR}
-wget ${FLINK_TARBALL_URI}
-tar -zxvf ${FLINK_TARBALL_NAME}
-mv ${FLINK_EXTRACT_DIRECTORY}/* .
-rm ${FLINK_TARBALL_NAME}
-rmdir ${FLINK_EXTRACT_DIRECTORY}
+# NOTE: This should really be the memory per worker (rather than per master).
+local total_mem=$(free -m | awk '/^Mem:/{print $2}')
+local flink_jobmanager_memory=$(python -c \
+    "print int(${total_mem} * ${FLINK_JOBMANAGER_MEMORY_FRACTION})")
+local flink_taskmanager_memory=$(python -c \
+    "print int(${total_mem} * ${FLINK_TASKMANAGER_MEMORY_FRACTION})")
 
 # Apply Flink settings by appending them to the default config
 cat << EOF >> ${FLINK_INSTALL_DIR}/conf/flink-conf.yaml
 # Settings applied by Cloud Dataproc initialization action
 jobmanager.rpc.address: ${MASTER_HOSTNAME}
-jobmanager.heap.mb: ${FLINK_JOBMANAGER_MEMORY}
-taskmanager.heap.mb: ${FLINK_TASKMANAGER_MEMORY}
-taskmanager.numberOfTaskSlots: ${FLINK_TASKMANAGER_SLOTS}
-parallelism.default: ${FLINK_PARALLELISM}
+jobmanager.heap.mb: ${flink_jobmanager_memory}
+taskmanager.heap.mb: ${flink_taskmanager_memory}
+taskmanager.numberOfTaskSlots: ${flink_taskmanager_slots}
+parallelism.default: ${flink_parallelism}
 taskmanager.network.numberOfBuffers: ${FLINK_NETWORK_NUM_BUFFERS}
 fs.hdfs.hadoopconf: ${HADOOP_CONF_DIR}
 EOF
 
-# Start a Flink YARN session
-HADOOP_CONF_DIR=/etc/hadoop/conf ./bin/yarn-session.sh -n \
-	${FLINK_TASKMANAGER_SLOTS} --detached
+if [ "$START_FLINK_YARN_SESSION" = "true" ] ; then
+  env HADOOP_CONF_DIR="$HADOOP_CONF_DIR" \
+    "$FLINK_INSTALL_DIR/bin/yarn-session.sh" \
+    -n "${num_workers}" \
+    --detached
+fi
+
+}
+
+function main() {
+local role="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+if [[ "${role}" == 'Master' ]]; then
+  apt-get install -y flink
+  configure_flink
+fi
+}
+
+main
+
+set +x +e


### PR DESCRIPTION
The flink download links were broken and some configuration variables were set incorrectly. This action now installs flink via apt-get and only runs on the master. 