### PR TITLE
add apache drill initialization action

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ These samples are provided to show how various packages and components can be in
 This repository presently offers the following actions for use with Cloud Dataproc clusters.
 
 * Install packages/software on the cluster
+  * [Apache Drill](http://drill.apache.org)
   * [Apache Flink](http://flink.apache.org)
   * [Apache Kafka](http://kafka.apache.org)
   * [Apache Oozie](http://oozie.apache.org)

--- a/drill/README.md
+++ b/drill/README.md
@@ -23,9 +23,14 @@ You can run the following to get into sqlline, the Drill CLI query tool:
 
 `sudo -u drill /usr/lib/drill/bin/sqlline -u jdbc:drill:`
 
+If you prefer to run drill as your user, set `DRILL_LOG_DIR` to someplace you have permission to write to:
+
+`DRILL_LOG_DIR=~/logs /usr/lib/drill/bin/sqlline -u jdbc:drill:`
+
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 
 ## Important notes
 * This script must be updated based on which Drill version you wish you install
 * This script must be updated based on your Cloud Dataproc cluster
 * Access to the Drill UI is possible via SSH forwarding to port 8047 on any drillbit, or with a [SOCKS proxy via SSH](https://cloud.google.com/solutions/connecting-securely#socks-proxy-over-ssh).
+

--- a/drill/README.md
+++ b/drill/README.md
@@ -8,12 +8,13 @@ Check the variables set in the script to ensure they're to your liking.
 
 Once you have configured a copy of this script, you can use this initialization action to create a new Dataproc cluster with Drill installed by:
 
-1. Uploading a copy of the initialization action (`drill.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-1. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
+1. Uploading a copy of the [initialization action for zookeeper](https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/tree/master/zookeeper) to [Google Cloud Storage](https://cloud.google.com/storage).
+1. Uploading a copy of the initialization action (`drill.sh`) to GCS.
+1. Using the `gcloud` command to create a new cluster with zookeeper and this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://<GCS_BUCKET>/drill.sh   
+    --initialization-actions gs://<GCS_BUCKET>/zookeeper.sh,gs://<GCS_BUCKET>/drill.sh
     --initialization-action-timeout 5m
     ```
 1. Once the cluster has been created, Drillbits will start on all nodes. You can log into any node of the cluster to run Drill queries. Drill is installed in `/usr/lib/drill` (unless you change the setting) which contains a `bin` directory with `sqlline`.
@@ -27,3 +28,4 @@ You can find more information about using initialization actions with Dataproc i
 ## Important notes
 * This script must be updated based on which Drill version you wish you install
 * This script must be updated based on your Cloud Dataproc cluster
+* Access to the Drill UI is possible via SSH forwarding to port 8047 on any drillbit, or with a [SOCKS proxy via SSH](https://cloud.google.com/solutions/connecting-securely#socks-proxy-over-ssh).

--- a/drill/README.md
+++ b/drill/README.md
@@ -1,0 +1,29 @@
+# Apache Drill Initialization Action
+
+This initialization action installs [Apache Drill](http://drill.apache.org) on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. The script will also start drillbits on all nodes of the cluster.
+
+## Using this initialization action
+
+Check the variables set in the script to ensure they're to your liking.
+
+Once you have configured a copy of this script, you can use this initialization action to create a new Dataproc cluster with Drill installed by:
+
+1. Uploading a copy of the initialization action (`drill.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+1. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
+
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://<GCS_BUCKET>/drill.sh   
+    --initialization-action-timeout 5m
+    ```
+1. Once the cluster has been created, Drillbits will start on all nodes. You can log into any node of the cluster to run Drill queries. Drill is installed in `/usr/lib/drill` (unless you change the setting) which contains a `bin` directory with `sqlline`.
+
+You can run the following to get into sqlline, the Drill CLI query tool:
+
+`sudo -u drill /usr/lib/drill/bin/sqlline -u jdbc:drill:`
+
+You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+
+## Important notes
+* This script must be updated based on which Drill version you wish you install
+* This script must be updated based on your Cloud Dataproc cluster

--- a/drill/README.md
+++ b/drill/README.md
@@ -28,7 +28,7 @@ You can find more information about using initialization actions with Dataproc i
 ## Important notes
 * This script must be updated based on which Drill version you wish you install
 * This script must be updated based on your Cloud Dataproc cluster
-* Access to the Drill UI is possible via SSH forwarding to port 8047 on any drillbit, or with a [SOCKS proxy via SSH](https://cloud.google.com/solutions/connecting-securely#socks-proxy-over-ssh). Pro-tip: You can run an incognito window of Chrome with your SOCKS proxy like this: 
+* Access to the Drill UI is possible via SSH forwarding to port 8047 on any drillbit, or with a [SOCKS proxy via SSH](https://cloud.google.com/solutions/connecting-securely#socks-proxy-over-ssh). Pro-tip: You can run an incognito window of Chrome on macOS with your SOCKS proxy like this: 
 
 ```
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --args --incognito --proxy-server=localhost:1080

--- a/drill/README.md
+++ b/drill/README.md
@@ -27,10 +27,37 @@ If you prefer to run drill as your user, set `DRILL_LOG_DIR` to someplace you ha
 
 `DRILL_LOG_DIR=~/logs /usr/lib/drill/bin/sqlline -u jdbc:drill:`
 
+Once in sqlline, you can see what storage plugins are available. Out of the box, this initialization action supports GCS (gs), HDFS (hdfs), local linux file system (dfs) and Hive (hive):
+
+```
+$ DRILL_LOG_DIR=~/logs /usr/lib/drill/bin/sqlline -u jdbc:drill:
+OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=512M; support was removed in 8.0
+apache drill 1.9.0
+"just drill it"
+0: jdbc:drill:> show databases;
++---------------------+
+|     SCHEMA_NAME     |
++---------------------+
+| INFORMATION_SCHEMA  |
+| cp.default          |
+| dfs.default         |
+| dfs.root            |
+| dfs.tmp             |
+| gs.default          |
+| gs.root             |
+| hdfs.default        |
+| hdfs.root           |
+| hdfs.tmp            |
+| hive.default        |
+| sys                 |
++---------------------+
+12 rows selected (3.943 seconds)
+```
+
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 
 ## Important notes
 * This script must be updated based on which Drill version you wish you install
 * This script must be updated based on your Cloud Dataproc cluster
 * Access to the Drill UI is possible via SSH forwarding to port 8047 on any drillbit, or with a [SOCKS proxy via SSH](https://cloud.google.com/solutions/connecting-securely#socks-proxy-over-ssh).
-
+* By default your Drill query profiles are stored in GCS in your cluster's dataproc bucket, as returned by `/usr/share/google/get_metadata_value attributes/dataproc-bucket`. You can change this in `drill.sh`.

--- a/drill/README.md
+++ b/drill/README.md
@@ -28,9 +28,4 @@ You can find more information about using initialization actions with Dataproc i
 ## Important notes
 * This script must be updated based on which Drill version you wish you install
 * This script must be updated based on your Cloud Dataproc cluster
-* Access to the Drill UI is possible via SSH forwarding to port 8047 on any drillbit, or with a [SOCKS proxy via SSH](https://cloud.google.com/solutions/connecting-securely#socks-proxy-over-ssh). Pro-tip: You can run an incognito window of Chrome on macOS with your SOCKS proxy like this: 
-
-```
-/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
-  --args --incognito --proxy-server=localhost:1080
-```
+* Access to the Drill UI is possible via SSH forwarding to port 8047 on any drillbit, or with a [SOCKS proxy via SSH](https://cloud.google.com/solutions/connecting-securely#socks-proxy-over-ssh).

--- a/drill/README.md
+++ b/drill/README.md
@@ -28,4 +28,8 @@ You can find more information about using initialization actions with Dataproc i
 ## Important notes
 * This script must be updated based on which Drill version you wish you install
 * This script must be updated based on your Cloud Dataproc cluster
-* Access to the Drill UI is possible via SSH forwarding to port 8047 on any drillbit, or with a [SOCKS proxy via SSH](https://cloud.google.com/solutions/connecting-securely#socks-proxy-over-ssh).
+* Access to the Drill UI is possible via SSH forwarding to port 8047 on any drillbit, or with a [SOCKS proxy via SSH](https://cloud.google.com/solutions/connecting-securely#socks-proxy-over-ssh). Pro-tip: You can run an incognito window of Chrome with your SOCKS proxy like this: 
+
+```
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --args --incognito --proxy-server=localhost:1080
+```

--- a/drill/README.md
+++ b/drill/README.md
@@ -31,5 +31,6 @@ You can find more information about using initialization actions with Dataproc i
 * Access to the Drill UI is possible via SSH forwarding to port 8047 on any drillbit, or with a [SOCKS proxy via SSH](https://cloud.google.com/solutions/connecting-securely#socks-proxy-over-ssh). Pro-tip: You can run an incognito window of Chrome on macOS with your SOCKS proxy like this: 
 
 ```
-/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --args --incognito --proxy-server=localhost:1080
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --args --incognito --proxy-server=localhost:1080
 ```

--- a/drill/drill.sh
+++ b/drill/drill.sh
@@ -46,6 +46,12 @@ ln -sf /usr/lib/hadoop/lib/gcs-connector-1.6.0-hadoop2.jar $DRILL_HOME/jars/3rdp
 # Symlink core-site.xml to $DRILL_HOME/conf
 ln -sf /etc/hadoop/conf/core-site.xml /etc/drill/conf
 
+# Set ZK PStore to use a GCS Bucket
+# Makes all Drill profiles available from any drillbit
+cat >> $DRILL_HOME/conf/drill-override.conf <<EOF
+drill.exec: { sys.store.provider.zk.blobroot: "$DATAPROC_BUCKET/pstore/" }
+EOF
+
 # Start drillbit
 sudo -u $DRILL_USER $DRILL_HOME/bin/drillbit.sh status ||\
 	sudo -u $DRILL_USER $DRILL_HOME/bin/drillbit.sh start && sleep 10

--- a/drill/drill.sh
+++ b/drill/drill.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -x -e
+
+# where we should install drill
+DRILL_USER_HOME=/var/lib/drill
+DRILL_HOME=/usr/lib/drill
+DRILL_LOG_DIR=/var/log/drill
+DRILL_VERSION="1.9.0"
+
+
+# Determine the role of this node
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+# Determine the cluster name
+CLUSTER=$(/usr/share/google/get_metadata_value attributes/dataproc-cluster-name)
+
+# naively generate the zookeeper string
+ZK=$CLUSTER-m:2181,$CLUSTER-w-0:2181,$CLUSTER-w-1:2181
+
+# Create drill pseudo-user.
+useradd -r -m -d $DRILL_USER_HOME drill || echo
+
+# Create drill home
+mkdir -p $DRILL_HOME && chown drill:drill $DRILL_HOME
+
+# Download and unpack Drill as the pseudo-user.
+curl -L http://apache.mirrors.lucidnetworks.net/drill/drill-$DRILL_VERSION/apache-drill-$DRILL_VERSION.tar.gz | sudo -u drill tar --strip-components=1 -C $DRILL_HOME -vxzf -
+
+# Replace default configuration with cluster-specific.
+sed -i "s/drillbits1/$CLUSTER/" $DRILL_HOME/conf/drill-override.conf
+sed -i "s/localhost:2181/$ZK/" $DRILL_HOME/conf/drill-override.conf
+
+# Make the log directory
+mkdir -p $DRILL_LOG_DIR && chown drill:drill $DRILL_LOG_DIR
+
+# Symlink drill conf dir to /etc
+mkdir -p /etc/drill && ln -sf $DRILL_HOME/conf /etc/drill/
+
+# Point drill logs to $DRILL_LOG_DIR
+echo DRILL_LOG_DIR=$DRILL_LOG_DIR >> $DRILL_HOME/conf/drill-env.sh
+
+# Create the hive storage plugin
+cat > /tmp/hive_plugin.json <<EOF
+{
+"name": "hive",
+"config": {
+    "type": "hive",
+    "enabled": true,
+    "configProps": {
+    "hive.metastore.uris": "thrift://$CLUSTER-m:9083",
+    "hive.metastore.sasl.enabled": "false",
+    "fs.default.name": "hdfs://$CLUSTER-m/"
+    }
+  }
+}
+EOF
+
+curl -d@/tmp/hive_plugin.json -H "Content-Type: application/json" -X POST http://localhost:8047/storage/hive.json
+
+# Clean up
+rm -f /tmp/drill_plugin.json
+
+set +x +e

--- a/drill/drill.sh
+++ b/drill/drill.sh
@@ -13,6 +13,7 @@ DRILL_VERSION="1.9.0"
 ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 # Determine the cluster name
 CLUSTER=$(/usr/share/google/get_metadata_value attributes/dataproc-cluster-name)
+DATAPROC_BUCKET=gs://$(/usr/share/google/get_metadata_value attributes/dataproc-bucket)
 
 # naively generate the zookeeper string
 ZK=$CLUSTER-m:2181,$CLUSTER-w-0:2181,$CLUSTER-w-1:2181
@@ -39,6 +40,12 @@ mkdir -p /etc/drill && ln -sf $DRILL_HOME/conf /etc/drill/
 # Point drill logs to $DRILL_LOG_DIR
 echo DRILL_LOG_DIR=$DRILL_LOG_DIR >> $DRILL_HOME/conf/drill-env.sh
 
+# Copy GCS connector to drill jars
+ln -sf /usr/lib/hadoop/lib/gcs-connector-1.6.0-hadoop2.jar $DRILL_HOME/jars/3rdparty
+
+# Symlink core-site.xml to $DRILL_HOME/conf
+ln -sf /etc/hadoop/conf/core-site.xml /etc/drill/conf
+
 # Start drillbit
 sudo -u $DRILL_USER $DRILL_HOME/bin/drillbit.sh status ||\
 	sudo -u $DRILL_USER $DRILL_HOME/bin/drillbit.sh start && sleep 10
@@ -59,9 +66,83 @@ cat > /tmp/hive_plugin.json <<EOF
 }
 EOF
 
+# Create GCS storage plugin
+cat > /tmp/gcs_plugin.json <<EOF
+{
+    "config": {
+        "connection": "$DATAPROC_BUCKET",
+        "enabled": true,
+        "formats": {
+            "avro": {
+                "type": "avro"
+            },
+            "csv": {
+                "delimiter": ",",
+                "extensions": [
+                    "csv"
+                ],
+                "type": "text"
+            },
+            "csvh": {
+                "delimiter": ",",
+                "extensions": [
+                    "csvh"
+                ],
+                "extractHeader": true,
+                "type": "text"
+            },
+            "json": {
+                "extensions": [
+                    "json"
+                ],
+                "type": "json"
+            },
+            "parquet": {
+                "type": "parquet"
+            },
+            "psv": {
+                "delimiter": "|",
+                "extensions": [
+                    "tbl"
+                ],
+                "type": "text"
+            },
+            "sequencefile": {
+                "extensions": [
+                    "seq"
+                ],
+                "type": "sequencefile"
+            },
+            "tsv": {
+                "delimiter": "\t",
+                "extensions": [
+                    "tsv"
+                ],
+                "type": "text"
+            }
+        },
+        "type": "file",
+        "workspaces": {
+            "root": {
+                "defaultInputFormat": null,
+                "location": "/",
+                "writable": false
+            },
+            "tmp": {
+                "defaultInputFormat": null,
+                "location": "/tmp",
+                "writable": true
+            }
+        }
+    },
+    "name": "gs"
+}
+EOF
+
 curl -d@/tmp/hive_plugin.json -H "Content-Type: application/json" -X POST http://localhost:8047/storage/hive.json
+curl -d@/tmp/gcs_plugin.json -H "Content-Type: application/json" -X POST http://localhost:8047/storage/gs.json
 
 # Clean up
-rm -f /tmp/drill_plugin.json
+rm -f /tmp/*_plugin.json
 
 set +x +e


### PR DESCRIPTION
Lightly tested. Out-of-box works with the default dataproc GCS bucket, HDFS, local linux fs (not really very useful!) and Hive.