### PR TITLE
The '--' argument must be specified between gcloud specific args on t…

### DIFF
--- a/datalab/datalab.sh
+++ b/datalab/datalab.sh
@@ -28,7 +28,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
   if [[ -z "${DOCKER_IMAGE}" ]]; then
     DOCKER_IMAGE="gcr.io/cloud-datalab/datalab:local"
   fi
-  gcloud docker pull ${DOCKER_IMAGE}
+  gcloud docker -- pull ${DOCKER_IMAGE}
 
   # For some reason Spark has issues resolving the user's directory inside of
   # Datalab.


### PR DESCRIPTION
…he left and DOCKER_ARGS on the right.

previously, gcloud allowed the omission of the --, and unparsed arguments were treated as implementation args. This usage has been removed, and so the initialization action now fails.  Please update gs://dataproc-initialization-actions/