### PR TITLE
conda bootstrap cleanup

### DIFF
--- a/conda/bootstrap-conda.sh
+++ b/conda/bootstrap-conda.sh
@@ -7,92 +7,92 @@ set -e
 #ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 #if [[ "${ROLE}" == 'Master' ]]; then
 
-
-if [[ -f "/etc/profile.d/conda.sh" ]]; then
-    echo "file /etc/profile.d/conda.sh exists! Dataproc has installed conda previously. Skipping install!"
-    command -v conda >/dev/null && echo "conda command detected in $PATH"
-    exit 0
-fi
-
 if [[ ! -v CONDA_INSTALL_PATH ]]; then
     echo "CONDA_INSTALL_PATH not set, setting ..."
     CONDA_INSTALL_PATH="/opt/conda"
     echo "Set CONDA_INSTALL_PATH to $CONDA_INSTALL_PATH"
 fi
-# 0. Specify Miniconda version
-## 0.1 A few parameters
-## specify base operating system
-if [[ ! -v OS_TYPE ]]; then
-    echo "OS_TYPE not set, setting  ..."
-    OS_TYPE="Linux-x86_64.sh"
-    echo "Set OS_TYPE to $OS_TYPE"
-fi
-## Python 2 or 3 based miniconda?
-if [[ ! -v MINICONDA_VARIANT ]]; then
-    echo "MINICONDA_VARIANT not set, setting ... "
-    MINICONDA_VARIANT="3"  #for Python 3.5.x
-    echo "Set MINICONDA_VARIANT to $MINICONDA_VARIANT"
-fi
-## specify Miniconda release (e.g., MINICONDA_VER='4.0.5')
-if [[ ! -v MINICONDA_VER ]]; then
-    echo "MINICONDA_VER not set, setting ..."
-    MINICONDA_VER='latest'
-    set "Set MINICONDA_VER to $MINICONDA_VER"
-fi
 
-## 0.2 Compute Miniconda version
-MINICONDA_FULL_NAME="Miniconda$MINICONDA_VARIANT-$MINICONDA_VER-$OS_TYPE"
-echo "Complete Miniconda version resolved to: $MINICONDA_FULL_NAME"
-## 0.3 Set MD5 hash for check (if desired)
-#expectedHash="b1b15a3436bb7de1da3ccc6e08c7a5df"
-
-# 1. Setup Miniconda Install
-## 1.1 Define Miniconda install directory
-echo "Working directory: $PWD"
-if [[ ! -v $PROJ_DIR ]]; then
-    echo "No path argument specified, setting install directory as working directory: $PWD."
-    PROJ_DIR=$PWD
-fi
-
-## 1.2 Setup Miniconda
-cd $PROJ_DIR
-MINICONDA_SCRIPT_PATH="$PROJ_DIR/$MINICONDA_FULL_NAME"
-echo "Defined Miniconda script path: $MINICONDA_SCRIPT_PATH"
-
-if [[ -f "$MINICONDA_SCRIPT_PATH" ]]; then
-  echo "Found existing Miniconda script at: $MINICONDA_SCRIPT_PATH"
+if [[ -f "/etc/profile.d/conda.sh" ]]; then
+    echo "file /etc/profile.d/conda.sh exists! Dataproc has installed conda previously. Skipping install!"
+    command -v conda >/dev/null && echo "conda command detected in $PATH"
 else
-  echo "Downloading Miniconda script to: $MINICONDA_SCRIPT_PATH ..."
-  wget https://repo.continuum.io/miniconda/$MINICONDA_FULL_NAME -P "$PROJ_DIR"
-  echo "Downloaded $MINICONDA_FULL_NAME!"
-  ls -al $MINICONDA_SCRIPT_PATH
-  chmod 755 $MINICONDA_SCRIPT_PATH
-fi
 
-## 1.3 #md5sum hash check of miniconda installer
-if [[ -v expectedHash ]]; then
-    md5Output=$(md5sum $MINICONDA_SCRIPT_PATH | awk '{print $1}')
-    if [ "$expectedHash" != "$md5Output" ]; then
-        echo "Unexpected md5sum $md5Output for $MINICONDA_FULL_NAME"
-        exit 1
+    # 0. Specify Miniconda version
+    ## 0.1 A few parameters
+    ## specify base operating system
+    if [[ ! -v OS_TYPE ]]; then
+        echo "OS_TYPE not set, setting  ..."
+        OS_TYPE="Linux-x86_64.sh"
+        echo "Set OS_TYPE to $OS_TYPE"
     fi
-fi
+    ## Python 2 or 3 based miniconda?
+    if [[ ! -v MINICONDA_VARIANT ]]; then
+        echo "MINICONDA_VARIANT not set, setting ... "
+        MINICONDA_VARIANT="3"  #for Python 3.5.x
+        echo "Set MINICONDA_VARIANT to $MINICONDA_VARIANT"
+    fi
+    ## specify Miniconda release (e.g., MINICONDA_VER='4.0.5')
+    if [[ ! -v MINICONDA_VER ]]; then
+        echo "MINICONDA_VER not set, setting ..."
+        MINICONDA_VER='latest'
+        set "Set MINICONDA_VER to $MINICONDA_VER"
+    fi
 
-# 2. Install conda
-## 2.1 Via bootstrap
-LOCAL_CONDA_PATH="$PROJ_DIR/miniconda"
-if [[ ! -d $LOCAL_CONDA_PATH ]]; then
-    #blow away old symlink / default Miniconda install
-    rm -rf "$PROJ_DIR/miniconda"
-    # Install Miniconda
-    echo "Installing $MINICONDA_FULL_NAME to $CONDA_INSTALL_PATH..."
-    bash $MINICONDA_SCRIPT_PATH -b -p $CONDA_INSTALL_PATH -f
-    chmod 755 $CONDA_INSTALL_PATH
-    #create symlink
-    ln -sf $CONDA_INSTALL_PATH "$PROJ_DIR/miniconda"
-    chmod 755 "$PROJ_DIR/miniconda"
-else
-    echo "Existing directory at path: $LOCAL_CONDA_PATH, skipping install!"
+    ## 0.2 Compute Miniconda version
+    MINICONDA_FULL_NAME="Miniconda$MINICONDA_VARIANT-$MINICONDA_VER-$OS_TYPE"
+    echo "Complete Miniconda version resolved to: $MINICONDA_FULL_NAME"
+    ## 0.3 Set MD5 hash for check (if desired)
+    #expectedHash="b1b15a3436bb7de1da3ccc6e08c7a5df"
+
+    # 1. Setup Miniconda Install
+    ## 1.1 Define Miniconda install directory
+    echo "Working directory: $PWD"
+    if [[ ! -v $PROJ_DIR ]]; then
+        echo "No path argument specified, setting install directory as working directory: $PWD."
+        PROJ_DIR=$PWD
+    fi
+
+    ## 1.2 Setup Miniconda
+    cd $PROJ_DIR
+    MINICONDA_SCRIPT_PATH="$PROJ_DIR/$MINICONDA_FULL_NAME"
+    echo "Defined Miniconda script path: $MINICONDA_SCRIPT_PATH"
+
+    if [[ -f "$MINICONDA_SCRIPT_PATH" ]]; then
+      echo "Found existing Miniconda script at: $MINICONDA_SCRIPT_PATH"
+    else
+      echo "Downloading Miniconda script to: $MINICONDA_SCRIPT_PATH ..."
+      wget https://repo.continuum.io/miniconda/$MINICONDA_FULL_NAME -P "$PROJ_DIR"
+      echo "Downloaded $MINICONDA_FULL_NAME!"
+      ls -al $MINICONDA_SCRIPT_PATH
+      chmod 755 $MINICONDA_SCRIPT_PATH
+    fi
+
+    ## 1.3 #md5sum hash check of miniconda installer
+    if [[ -v expectedHash ]]; then
+        md5Output=$(md5sum $MINICONDA_SCRIPT_PATH | awk '{print $1}')
+        if [ "$expectedHash" != "$md5Output" ]; then
+            echo "Unexpected md5sum $md5Output for $MINICONDA_FULL_NAME"
+            exit 1
+        fi
+    fi
+
+    # 2. Install conda
+    ## 2.1 Via bootstrap
+    LOCAL_CONDA_PATH="$PROJ_DIR/miniconda"
+    if [[ ! -d $LOCAL_CONDA_PATH ]]; then
+        #blow away old symlink / default Miniconda install
+        rm -rf "$PROJ_DIR/miniconda"
+        # Install Miniconda
+        echo "Installing $MINICONDA_FULL_NAME to $CONDA_INSTALL_PATH..."
+        bash $MINICONDA_SCRIPT_PATH -b -p $CONDA_INSTALL_PATH -f
+        chmod 755 $CONDA_INSTALL_PATH
+        #create symlink
+        ln -sf $CONDA_INSTALL_PATH "$PROJ_DIR/miniconda"
+        chmod 755 "$PROJ_DIR/miniconda"
+    else
+        echo "Existing directory at path: $LOCAL_CONDA_PATH, skipping install!"
+    fi
 fi
 
 ## 2.2 Update PATH and conda...
@@ -140,7 +140,12 @@ fi
 ## 3. Ensure that Anaconda Python and PySpark play nice
 ### http://blog.cloudera.com/blog/2015/09/how-to-prepare-your-apache-hadoop-cluster-for-pyspark-jobs/
 echo "Ensure that Anaconda Python and PySpark play nice by all pointing to same Python distro..."
-if [[ ! -v PYSPARK_PYTHON ]]; then  echo "export PYSPARK_PYTHON=$CONDA_BIN_PATH/python" | tee -a  /etc/profile.d/conda.sh   /etc/environment /usr/lib/spark/conf/spark-env.sh; fi
+if grep -ir "export PYSPARK_PYTHON=$CONDA_BIN_PATH/python" /etc/profile.d/conda.sh
+    then
+    echo "export PYSPARK_PYTHON=$CONDA_BIN_PATH/python detected in /etc/profile.d/conda.sh , skipping..."
+else
+    echo "export PYSPARK_PYTHON=$CONDA_BIN_PATH/python" | tee -a  /etc/profile.d/conda.sh /etc/environment /usr/lib/spark/conf/spark-env.sh
+fi
 
 echo "Finished bootstrapping via Miniconda, sourcing /etc/profile ..."
 source /etc/profile

--- a/conda/bootstrap-conda.sh
+++ b/conda/bootstrap-conda.sh
@@ -60,7 +60,7 @@ if [[ -f "$MINICONDA_SCRIPT_PATH" ]]; then
   echo "Found existing Miniconda script at: $MINICONDA_SCRIPT_PATH"
 else
   echo "Downloading Miniconda script to: $MINICONDA_SCRIPT_PATH ..."
-  wget http://repo.continuum.io/miniconda/$miniconda -P "$PROJ_DIR"
+  wget https://repo.continuum.io/miniconda/$miniconda -P "$PROJ_DIR"
   echo "Downloaded $miniconda!"
   ls -al $MINICONDA_SCRIPT_PATH
   chmod 755 $MINICONDA_SCRIPT_PATH

--- a/conda/bootstrap-conda.sh
+++ b/conda/bootstrap-conda.sh
@@ -16,7 +16,7 @@ fi
 
 if [[ ! -v CONDA_INSTALL_PATH ]]; then
     echo "CONDA_INSTALL_PATH not set, setting ..."
-    CONDA_INSTALL_PATH="/usr/local/bin/miniconda"
+    CONDA_INSTALL_PATH="/opt/conda"
     echo "Set CONDA_INSTALL_PATH to $CONDA_INSTALL_PATH"
 fi
 # 0. Specify Miniconda version
@@ -27,15 +27,12 @@ if [[ ! -v OS_TYPE ]]; then
     OS_TYPE="Linux-x86_64.sh"
     echo "Set OS_TYPE to $OS_TYPE"
 fi
-## Python 2 or 3?
+## Python 2 or 3 based miniconda?
 if [[ ! -v MINICONDA_VARIANT ]]; then
     echo "MINICONDA_VARIANT not set, setting ... "
-    MINICONDA_VARIANT="Miniconda3"  #for Python 3.5.x
+    MINICONDA_VARIANT="3"  #for Python 3.5.x
     echo "Set MINICONDA_VARIANT to $MINICONDA_VARIANT"
-else
-    MINICONDA_VARIANT="Miniconda$MINICONDA_VARIANT"
 fi
-
 ## specify Miniconda release (e.g., MINICONDA_VER='4.0.5')
 if [[ ! -v MINICONDA_VER ]]; then
     echo "MINICONDA_VER not set, setting ..."
@@ -44,8 +41,8 @@ if [[ ! -v MINICONDA_VER ]]; then
 fi
 
 ## 0.2 Compute Miniconda version
-miniconda="$MINICONDA_VARIANT-$MINICONDA_VER-$OS_TYPE"
-echo "Miniconda version specified: $miniconda"
+MINICONDA_FULL_NAME="Miniconda$MINICONDA_VARIANT-$MINICONDA_VER-$OS_TYPE"
+echo "Complete Miniconda version resolved to: $MINICONDA_FULL_NAME"
 ## 0.3 Set MD5 hash for check (if desired)
 #expectedHash="b1b15a3436bb7de1da3ccc6e08c7a5df"
 
@@ -59,15 +56,15 @@ fi
 
 ## 1.2 Setup Miniconda
 cd $PROJ_DIR
-MINICONDA_SCRIPT_PATH="$PROJ_DIR/$miniconda"
-echo "Defined miniconda script path: $MINICONDA_SCRIPT_PATH"
+MINICONDA_SCRIPT_PATH="$PROJ_DIR/$MINICONDA_FULL_NAME"
+echo "Defined Miniconda script path: $MINICONDA_SCRIPT_PATH"
 
 if [[ -f "$MINICONDA_SCRIPT_PATH" ]]; then
   echo "Found existing Miniconda script at: $MINICONDA_SCRIPT_PATH"
 else
   echo "Downloading Miniconda script to: $MINICONDA_SCRIPT_PATH ..."
-  wget https://repo.continuum.io/miniconda/$miniconda -P "$PROJ_DIR"
-  echo "Downloaded $miniconda!"
+  wget https://repo.continuum.io/miniconda/$MINICONDA_FULL_NAME -P "$PROJ_DIR"
+  echo "Downloaded $MINICONDA_FULL_NAME!"
   ls -al $MINICONDA_SCRIPT_PATH
   chmod 755 $MINICONDA_SCRIPT_PATH
 fi
@@ -76,7 +73,7 @@ fi
 if [[ -v expectedHash ]]; then
     md5Output=$(md5sum $MINICONDA_SCRIPT_PATH | awk '{print $1}')
     if [ "$expectedHash" != "$md5Output" ]; then
-        echo "Unexpected md5sum $md5Output for $miniconda"
+        echo "Unexpected md5sum $md5Output for $MINICONDA_FULL_NAME"
         exit 1
     fi
 fi
@@ -88,7 +85,7 @@ if [[ ! -d $LOCAL_CONDA_PATH ]]; then
     #blow away old symlink / default Miniconda install
     rm -rf "$PROJ_DIR/miniconda"
     # Install Miniconda
-    echo "Installing $miniconda to $CONDA_INSTALL_PATH..."
+    echo "Installing $MINICONDA_FULL_NAME to $CONDA_INSTALL_PATH..."
     bash $MINICONDA_SCRIPT_PATH -b -p $CONDA_INSTALL_PATH -f
     chmod 755 $CONDA_INSTALL_PATH
     #create symlink
@@ -108,22 +105,30 @@ hash -r
 which conda
 conda config --set always_yes true --set changeps1 false
 
-# Useful for debugging any issues with conda
+# Useful printout for debugging any issues with conda
 conda info -a
 
-
-# 2.3 Update global profiles to add the miniconda location to PATH and PYTHONHASHSEED
+## 2.3 Update global profiles to add the miniconda location to PATH
 # based on: http://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux
 # and also: http://askubuntu.com/questions/391515/changing-etc-environment-did-not-affect-my-environemtn-variables
 # and this: http://askubuntu.com/questions/128413/setting-the-path-so-it-applies-to-all-users-including-root-sudo
-echo "Updating global profiles to export miniconda bin location to PATH and set PYTHONHASHSEED ..."
-if [[ -f "/etc/profile.d/conda.sh" ]]
+echo "Updating global profiles to export miniconda bin location to PATH..."
+if grep -ir "CONDA_BIN_PATH=$CONDA_BIN_PATH" /etc/profile.d/conda.sh
     then
-    echo "file /etc/profile.d/conda.sh exists, skipping..."
+    echo "CONDA_BIN_PATH found in /etc/profile.d/conda.sh , skipping..."
 else
     echo "Adding path definition to profiles..."
-    echo "export CONDA_BIN_PATH=$CONDA_BIN_PATH" | tee -a /etc/profile.d/conda.sh  #/etc/*bashrc /etc/profile
+    echo "export CONDA_BIN_PATH=$CONDA_BIN_PATH" | tee -a /etc/profile.d/conda.sh #/etc/*bashrc /etc/profile
     echo 'export PATH=$CONDA_BIN_PATH:$PATH' | tee -a /etc/profile.d/conda.sh  #/etc/*bashrc /etc/profile
+
+fi
+
+# 2.3 Update global profiles to add the miniconda location to PATH
+echo "Updating global profiles to export miniconda bin location to PATH and set PYTHONHASHSEED ..."
+if grep -ir "export PYTHONHASHSEED=0" /etc/profile.d/conda.sh
+    then
+    echo "export PYTHONHASHSEED=0 detected in /etc/profile.d/conda.sh , skipping..."
+else
     # Fix issue with Python3 hash seed.
     # Issue here: https://issues.apache.org/jira/browse/SPARK-13330 (fixed in Spark 2.2.0 release)
     # Fix here: http://blog.stuart.axelbrooke.com/python-3-on-spark-return-of-the-pythonhashseed/
@@ -135,7 +140,7 @@ fi
 ## 3. Ensure that Anaconda Python and PySpark play nice
 ### http://blog.cloudera.com/blog/2015/09/how-to-prepare-your-apache-hadoop-cluster-for-pyspark-jobs/
 echo "Ensure that Anaconda Python and PySpark play nice by all pointing to same Python distro..."
-if [[ ! -v PYSPARK_PYTHON ]]; then  echo "export PYSPARK_PYTHON=$CONDA_BIN_PATH/python" | tee -a  /etc/profile.d/conda.sh  /etc/*bashrc /etc/environment /usr/lib/spark/conf/spark-env.sh; fi
+if [[ ! -v PYSPARK_PYTHON ]]; then  echo "export PYSPARK_PYTHON=$CONDA_BIN_PATH/python" | tee -a  /etc/profile.d/conda.sh   /etc/environment /usr/lib/spark/conf/spark-env.sh; fi
 
 echo "Finished bootstrapping via Miniconda, sourcing /etc/profile ..."
 source /etc/profile

--- a/conda/install-conda-env.sh
+++ b/conda/install-conda-env.sh
@@ -3,7 +3,7 @@ set -e
 
 # 0.1 Ensure we have conda installed and available on the PATH
 if [[ ! -v CONDA_BIN_PATH ]]; then
-    source /etc/profile.d/conda_config.sh
+    source /etc/profile.d/conda.sh
 fi
 
 echo "echo \$USER: $USER"
@@ -27,7 +27,7 @@ else
     CONDA_ENV_NAME='root'
 fi
 
-conda update --all
+#conda update --all
 # 1. Create conda environment
 # 1.1 Update conda env from conda environment.yml (if specified)
 # For Dataproc provisioning, we should install to root conda env.
@@ -76,22 +76,22 @@ if [[ -v PIP_PACKAGES ]]; then
 fi
 
 # 2. Append profiles with conda env source activate
-echo "Attempting to append /etc/profile.d/conda_config.sh to activate conda env at login..."
-if [[ -f "/etc/profile.d/conda_config.sh"  ]]  && [[ ! $CONDA_ENV_NAME == 'root' ]]
+echo "Attempting to append /etc/profile.d/conda.sh to activate conda env at login..."
+if [[ -f "/etc/profile.d/conda.sh"  ]]  && [[ ! $CONDA_ENV_NAME == 'root' ]]
     then
-    if grep -ir "source activate $CONDA_ENV_NAME" /etc/profile.d/conda_config.sh
+    if grep -ir "source activate $CONDA_ENV_NAME" /etc/profile.d/conda.sh
         then
-        echo "conda env activation found in /etc/profile.d/conda_config.sh, skipping..."
+        echo "conda env activation found in /etc/profile.d/conda.sh, skipping..."
     else
-        echo "Appending /etc/profile.d/conda_config.sh to activate conda env $CONDA_ENV_NAME for shell..."
-        sudo echo "source activate $CONDA_ENV_NAME" | tee -a /etc/profile.d/conda_config.sh
-        echo "./etc/profile.d/conda_config.sh successfully appended!"
+        echo "Appending /etc/profile.d/conda.sh to activate conda env $CONDA_ENV_NAME for shell..."
+        sudo echo "source activate $CONDA_ENV_NAME" | tee -a /etc/profile.d/conda.sh
+        echo "./etc/profile.d/conda.sh successfully appended!"
     fi
 elif [[ $CONDA_ENV_NAME == 'root' ]]
     then
     echo "The conda env specified is 'root', the default environment, no need to activate, skipping..."
 else
-    echo "No file detected at /etc/profile.d/conda_config.sh..."
+    echo "No file detected at /etc/profile.d/conda.sh..."
     echo "Are you sure you installed conda via bootstrap-conda.sh?"
     exit 1
 fi

--- a/jupyter/jupyter.sh
+++ b/jupyter/jupyter.sh
@@ -15,9 +15,8 @@ echo "Cloning fresh dataproc-initialization-actions from repo $INIT_ACTIONS_REPO
 git clone -b "$INIT_ACTIONS_BRANCH" --single-branch $INIT_ACTIONS_REPO
 # Ensure we have conda installed.
 ./dataproc-initialization-actions/conda/bootstrap-conda.sh
-#./dataproc-initialization-actions/conda/install-conda-env.sh
 
-source /etc/profile.d/conda_config.sh
+source /etc/profile.d/conda.sh
 
 if [ -n "${JUPYTER_CONDA_PACKAGES}" ]; then
   echo "Installing custom conda packages '$(echo ${JUPYTER_CONDA_PACKAGES} | tr ':' ' ')'"


### PR DESCRIPTION
This is a much needed cleanup of the conda bootstrap init action, specifically, by:
- conforming to default pathing + .profile script names in docker image at continuumio/miniconda3
- removing all conda updates (eliminating breaking version updates)
- making idempotent the conda .profile modifications