### PR TITLE
Refactor kafka.sh to install from dataproc distro.

### DIFF
--- a/kafka/README.MD
+++ b/kafka/README.MD
@@ -1,7 +1,6 @@
 # Kafka 
 
-This initialization action installs [Kafka](http://kafka.apache.org) on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. To install Kafka you must first install ZooKeeper. In the future Cloud Dataproc clusters may include ZooKeeper by default but in the meantime you can use the ZooKeeper initialization action in [this GitHub repository](https://github.com/GoogleCloudPlatform/dataproc-initialization-actions).
-
+This initialization action installs [Kafka](http://kafka.apache.org) on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. Kafka depends on Zookeeper, which can either be installed with a separate zookeeper initialization action or by simply creating a "High Availability" cluster using `--num-masters 3`.
 
 ## Using this initialization action
 You can use this initialization action to create a new Dataproc cluster with Kafka installed by:
@@ -11,14 +10,37 @@ You can use this initialization action to create a new Dataproc cluster with Kaf
    
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://<GCS_BUCKET>/kafka.sh   
-    --initialization-action-timeout 5m
+        --num-masters 3 \
+        --image-version preview \
+        --initialization-actions gs://dataproc-initialization-actions/kafka/kafka.sh
     ```
-1. Once the cluster has been created Kafka should be running on all worker nodes in the cluster. Kafka will use the three ZooKeeper nodes setup in `zookeeper.sh`.
+1. Once the cluster has been created Kafka should be running on all worker nodes in the cluster, and Kafka libraries should be installed on the master node(s). You can test your Kafka setup by creating a simple topic and publishing to it with Kafka's command-line tools, after SSH'ing into one of your master nodes:
+
+    ```bash
+    gcloud compute ssh <CLUSTER_NAME>-m-0
+
+    # Create a test topic, just talking to the local master's zookeeper server.
+    /usr/lib/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --create \
+        --replication-factor 1 --partitions 1 --topic test 
+    /usr/lib/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --list
+
+    # Use worker 0 as broker to publish 100 messages over 100 seconds
+    # asynchronously.
+    CLUSTER_NAME=$(/usr/share/google/get_metadata_value attributes/dataproc-cluster-name)
+    for i in {0..100}; do echo "message${i}"; sleep 1; done | \
+        /usr/lib/kafka/bin/kafka-console-producer.sh \
+        --broker-list ${CLUSTER_NAME}-w-0:9092 --topic test &
+
+    # User worker 1 as broker to consume those 100 messages as they come.
+    # This can also be run in any other master or worker node of the cluster.
+    /usr/lib/kafka/bin/kafka-console-consumer.sh \
+        --bootstrap-server ${CLUSTER_NAME}-w-1:9092 \
+        --topic test --from-beginning
+    ```
 
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 
 ## Important notes
-* This script will install Kafka on all **worker nodes** by default (but not the master)
-* This script assumes you have run the `zookeeper.sh` script to instal ZooKeeper on the master and two (required) worker nodes
+* This script will install Kafka on all **worker nodes** by default (but not the master(s))
+* This script assumes you have zookeeper installed, either through the zookeeper.sh init action or by creating a high-availability cluster with `--num-masters 3`
 * The `delete.topic.enable` property has been set to `true` by default so topics can be deleted


### PR DESCRIPTION
Make it more resilient to different zookeeper installations, and prefer
to use Dataproc HA to provide zookeeper masters. Add end-to-end
example.