### PR TITLE
Autostart Jupyter on node restart

### DIFF
--- a/jupyter/internal/launch-jupyter-kernel.sh
+++ b/jupyter/internal/launch-jupyter-kernel.sh
@@ -11,7 +11,8 @@ Description=Start Jupyter Notebook Server at reboot
 
 [Service]
 Type=simple
-ExecStart=/opt/conda/bin/jupyter notebook --allow-root  --no-browser
+ExecStart=/opt/conda/bin/jupyter notebook --allow-root  --no-browser \
+  > /var/log/jupyter_notebook.log 2>&1
 
 [Install]
 WantedBy=multi-user.target
@@ -20,12 +21,9 @@ EOF
 chmod a+rw ${INIT_SCRIPT}
 
 echo "Starting Jupyter notebook..."
-which jupyter
 
 systemctl daemon-reload
-echo "Reloaded..."
 systemctl enable jupyter-notebook
-echo "Enable..."
 systemctl start jupyter-notebook
 
 echo "Jupyter installation succeeded" >&2

--- a/jupyter/internal/launch-jupyter-kernel.sh
+++ b/jupyter/internal/launch-jupyter-kernel.sh
@@ -22,7 +22,11 @@ chmod a+rw ${INIT_SCRIPT}
 echo "Starting Jupyter notebook..."
 
 systemctl daemon-reload
+echo "Reloaded..."
+systemctl status jupyter-notebook
+echo "Status..."
 systemctl enable jupyter-notebook
+echo "Enable..."
 systemctl start jupyter-notebook
 
 echo "Jupyter installation succeeded" >&2

--- a/jupyter/internal/launch-jupyter-kernel.sh
+++ b/jupyter/internal/launch-jupyter-kernel.sh
@@ -11,7 +11,7 @@ Description=Start Jupyter Notebook Server at reboot
 
 [Service]
 Type=simple
-ExecStart=jupyter notebook --allow-root  --no-browser > /var/log/jupyter_notebook.log 2>&1
+ExecStart=jupyter notebook --allow-root  --no-browser
 
 [Install]
 WantedBy=multi-user.target

--- a/jupyter/internal/launch-jupyter-kernel.sh
+++ b/jupyter/internal/launch-jupyter-kernel.sh
@@ -1,6 +1,28 @@
 #!/usr/bin/env bash
 set -e
 
-echo "Starting Jupyter notebook..."
-nohup jupyter notebook --allow-root --no-browser > /var/log/jupyter_notebook.log 2>&1 &
+echo "Installing Jupyter service..."
 
+INIT_SCRIPT="/usr/lib/systemd/system/jupyter-notebook.service"
+
+cat << EOF > ${INIT_SCRIPT}
+[Unit]
+Description=Start Jupyter Notebook Server at reboot
+
+[Service]
+Type=simple
+ExecStart=jupyter notebook --allow-root  --no-browser > /var/log/jupyter_notebook.log 2>&1
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+chmod a+rw ${INIT_SCRIPT}
+
+echo "Starting Jupyter notebook..."
+
+systemctl daemon-reload
+systemctl enable jupyter-notebook
+systemctl start jupyter-notebook
+
+echo "Jupyter installation succeeded" >&2

--- a/jupyter/internal/launch-jupyter-kernel.sh
+++ b/jupyter/internal/launch-jupyter-kernel.sh
@@ -11,7 +11,7 @@ Description=Start Jupyter Notebook Server at reboot
 
 [Service]
 Type=simple
-ExecStart=/opt/conda/bin/jupyter notebook --allow-root  --no-browser > /var/log/jupyter_notebook.log 2>&1
+ExecStart=/opt/conda/bin/jupyter notebook --allow-root  --no-browser
 
 [Install]
 WantedBy=multi-user.target

--- a/jupyter/internal/launch-jupyter-kernel.sh
+++ b/jupyter/internal/launch-jupyter-kernel.sh
@@ -11,7 +11,7 @@ Description=Start Jupyter Notebook Server at reboot
 
 [Service]
 Type=simple
-ExecStart=jupyter notebook --allow-root  --no-browser
+ExecStart=/opt/conda/bin/jupyter notebook --allow-root  --no-browser > /var/log/jupyter_notebook.log 2>&1
 
 [Install]
 WantedBy=multi-user.target

--- a/jupyter/internal/launch-jupyter-kernel.sh
+++ b/jupyter/internal/launch-jupyter-kernel.sh
@@ -20,6 +20,7 @@ EOF
 chmod a+rw ${INIT_SCRIPT}
 
 echo "Starting Jupyter notebook..."
+which jupyter
 
 systemctl daemon-reload
 echo "Reloaded..."

--- a/jupyter/internal/launch-jupyter-kernel.sh
+++ b/jupyter/internal/launch-jupyter-kernel.sh
@@ -24,8 +24,6 @@ which jupyter
 
 systemctl daemon-reload
 echo "Reloaded..."
-systemctl status jupyter-notebook
-echo "Status..."
 systemctl enable jupyter-notebook
 echo "Enable..."
 systemctl start jupyter-notebook


### PR DESCRIPTION
Per https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/issues/108


For testing this, is the following the right strategy?

1. Edit jupyter.sh to point at my branch
2. Push jupyter.sh to GCS
3. Run gcloud dataproc clusters create