### PR TITLE
Disable long-running flink yarn session by default.

### DIFF
--- a/flink/README.md
+++ b/flink/README.md
@@ -22,12 +22,12 @@ Once you have configured a copy of this script, you can use this initialization 
     --initialization-actions gs://<GCS_BUCKET>/flink.sh   
     --initialization-action-timeout 5m
     ```
-1. Once the cluster has been created, Flink will start a session on YARN. You can log into the master node of the cluster to submit jobs to Flink. Flink is installed in `/usr/lib/flink` (unless you change the setting) which contains a `bin` directory with Flink. **Note** - you need to specify `HADOOP_CONF_DIR=/etc/hadoop/conf` before your Flink commands for them to execute properly.
+1. You can log into the master node of the cluster to submit jobs to Flink. Flink is installed in `/usr/lib/flink` (unless you change the setting) which contains a `bin` directory with Flink. **Note** - you need to specify `HADOOP_CONF_DIR=/etc/hadoop/conf` before your Flink commands for them to execute properly.
 
-For example, this command will run a word count sample (as root):
+For example, this command will run a word count job in its own yarn session with 2 containers (as root):
 
 `sudo su -
-HADOOP_CONF_DIR=/etc/hadoop/conf /usr/lib/flink/bin/flink run -m yarn-cluster examples/streaming/WordCount.jar`
+HADOOP_CONF_DIR=/etc/hadoop/conf /usr/lib/flink/bin/flink run -m yarn-cluster -yn 2 -j examples/streaming/WordCount.jar`
 
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 

--- a/flink/flink.sh
+++ b/flink/flink.sh
@@ -41,7 +41,7 @@ readonly FLINK_JOBMANAGER_MEMORY_FRACTION='1.0'
 readonly FLINK_TASKMANAGER_MEMORY_FRACTION='1.0'
 
 # Set this to true to start a flink yarn session at initialization time.
-readonly START_FLINK_YARN_SESSION="true"
+readonly START_FLINK_YARN_SESSION="false"
 
 function configure_flink() {
   # Number of worker nodes in your cluster


### PR DESCRIPTION
The yarn session is currently configured to consume all YARN resources. This makes it difficult to submit non-flink jobs to a cluster that has been started with the flink init action.

This change disables the default session. Users can always fork the script to change this setting or manually initiate their own sessions out-of-band.