### PR TITLE
Gate flink yarn session on GCE metadata

### DIFF
--- a/flink/README.md
+++ b/flink/README.md
@@ -22,9 +22,9 @@ Once you have configured a copy of this script, you can use this initialization 
     --initialization-actions gs://<GCS_BUCKET>/flink.sh   
     --initialization-action-timeout 5m
     ```
-1. 1. You can log into the master node of the cluster to submit jobs to Flink. Flink is installed in `/usr/lib/flink` (unless you change the setting) which contains a `bin` directory with Flink. **Note** - you need to specify `HADOOP_CONF_DIR=/etc/hadoop/conf` before your Flink commands for them to execute properly. By default, a detached Flink YARN session is started for you. To find its application id, run `yarn application -list`.
+1. 1. You can log into the master node of the cluster to submit jobs to Flink. Flink is installed in `/usr/lib/flink` (unless you change the setting) which contains a `bin` directory with Flink. **Note** - you need to specify `HADOOP_CONF_DIR=/etc/hadoop/conf` before your Flink commands for them to execute properly. 
 
-To run a job on the default session, run:
+To run a job on an existing YARN session, run:
 
 ```bash
 HADOOP_CONF_DIR=/etc/hadoop/conf /usr/lib/flink/bin/flink run -m yarn-cluster -yid <session application id> <job jar>
@@ -36,7 +36,7 @@ To run a job on a transient session using `N` containers:
 HADOOP_CONF_DIR=/etc/hadoop/conf /usr/lib/flink/bin/flink run -m yarn-cluster -yn N <job jar>
 ```
 
-For example, this command will run a word count sample (as root) on the default session:
+For example, this command will run a word count sample (as root) on an existing YARN session:
 ```bash
 sudo su - HADOOP_CONF_DIR=/etc/hadoop/conf /usr/lib/flink/bin/flink run -m yarn-cluster -yid <session application id> examples/streaming/WordCount.jar
 ```
@@ -44,5 +44,5 @@ sudo su - HADOOP_CONF_DIR=/etc/hadoop/conf /usr/lib/flink/bin/flink run -m yarn-
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 
 ## Important notes
-* This script must be updated based on which Flink version you wish you install
-* This script must be updated based on your Cloud Dataproc cluster
+* By default, a detached Flink YARN session is started for you. To find its application id, run `yarn application -list`.
+* The default session is configured to consume all YARN resources. If you want to submit multiple jobs in parallel or use transient sessions, you'll need to disable this default session. You can either fork this init script and set START_FLINK_YARN_SESSION_DEFAULT to `false`, or set the cluster metadata key `flink-start-yarn-session` to `false` when you create your cluster.

--- a/flink/README.md
+++ b/flink/README.md
@@ -22,12 +22,24 @@ Once you have configured a copy of this script, you can use this initialization 
     --initialization-actions gs://<GCS_BUCKET>/flink.sh   
     --initialization-action-timeout 5m
     ```
-1. Once the cluster has been created, Flink will start a session on YARN. You can log into the master node of the cluster to submit jobs to Flink. Flink is installed in `/usr/lib/flink` (unless you change the setting) which contains a `bin` directory with Flink. **Note** - you need to specify `HADOOP_CONF_DIR=/etc/hadoop/conf` before your Flink commands for them to execute properly.
+1. 1. You can log into the master node of the cluster to submit jobs to Flink. Flink is installed in `/usr/lib/flink` (unless you change the setting) which contains a `bin` directory with Flink. **Note** - you need to specify `HADOOP_CONF_DIR=/etc/hadoop/conf` before your Flink commands for them to execute properly. By default, a detached Flink YARN session is started for you. To find its application id, run `yarn application -list`.
 
-For example, this command will run a word count sample (as root):
+To run a job on the default session, run:
 
-`sudo su -
-HADOOP_CONF_DIR=/etc/hadoop/conf /usr/lib/flink/bin/flink run -m yarn-cluster examples/streaming/WordCount.jar`
+```bash
+HADOOP_CONF_DIR=/etc/hadoop/conf /usr/lib/flink/bin/flink run -m yarn-cluster -yid <session application id> <job jar>
+```
+
+To run a job on a transient session using `N` containers:
+
+```bash
+HADOOP_CONF_DIR=/etc/hadoop/conf /usr/lib/flink/bin/flink run -m yarn-cluster -yn N <job jar>
+```
+
+For example, this command will run a word count sample (as root) on the default session:
+```bash
+sudo su - HADOOP_CONF_DIR=/etc/hadoop/conf /usr/lib/flink/bin/flink run -m yarn-cluster -yid <session application id> examples/streaming/WordCount.jar
+```
 
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 

--- a/flink/README.md
+++ b/flink/README.md
@@ -4,15 +4,7 @@ This initialization action installs a binary release of [Apache Flink](http://fl
 Flink and start a Flink session running on YARN.
 
 ## Using this initialization action
-To use this initialization action, you will likely need to configure a few settings in the initialization action. Specifically, you shoud modify the following variables to match your desired setup:
-
-* `SCALA_VERSION` - The Scala version installed on the Cloud Dataproc cluster
-* `HADOOP_VERSION` - The Hadoop version installed on the Cloud Dataproc cluster
-* `FLINK_VERSION` - The Flink version to be installed
-
-The `SCALA_VERSION` and `HADOOP_VERSION` will be based on the [Cloud Dataproc image version](https://cloud.google.com/dataproc/concepts/dataproc-versions) you select. The `NUM_WORKERS` will be based on the number of workers you add to your cluster.
-
-Once you have configured a copy of this script, you can use this initialization action to create a new Dataproc cluster with Flink installed by:
+You can use this initialization action to create a new Dataproc cluster with Flink installed by:
 
 1. Uploading a copy of the initialization action (`flink.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
 1. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.


### PR DESCRIPTION
This allows the default behavior (whether or not a detached yarn session should be started) to be overridden based on the value of attributes/flink-start-yarn-session.

This change also fixes the jobmanager RPC address. This value was previously not being filled because the MASTER_HOSTNAME environment variable was unbound.