### PR TITLE
Only install Flink on primary master

### DIFF
--- a/flink/flink.sh
+++ b/flink/flink.sh
@@ -112,7 +112,9 @@ EOF
 
 function main() {
 local role="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
-if [[ "${role}" == 'Master' ]]; then
+local hostname="$(hostname)"
+local master_name="$(/usr/share/google/get_metadata_value attributes/dataproc-master)"
+if [[ "${role}" == 'Master' && "${hostname}" == "${master_name}" ]]; then
   apt-get install -y flink
   configure_flink
 fi

--- a/flink/flink.sh
+++ b/flink/flink.sh
@@ -77,12 +77,19 @@ function configure_flink() {
   local flink_taskmanager_memory=$(python -c \
       "print int(${worker_total_mem} * ${FLINK_TASKMANAGER_MEMORY_FRACTION})")
 
-  # Fetch the master name from metadata.
+  # Fetch the primary master name from metadata.
   local master_hostname="$(/usr/share/google/get_metadata_value attributes/dataproc-master)"
+  local hostname="$(hostname)"
 
-  # Determine whether to start a detached YARN session.
-  local start_flink_yarn_session="$(/usr/share/google/get_metadata_value "attributes/${START_FLINK_YARN_SESSION_METADATA_KEY}")"
-  start_flink_yarn_session="${start_flink_yarn_session:-${START_FLINK_YARN_SESSION_DEFAULT}}"
+  local start_flink_yarn_session
+  if [[ "${hostname}" == "${master_hostname}" ]] ; then
+    # Determine whether to start a detached session.
+    start_flink_yarn_session="$(/usr/share/google/get_metadata_value "attributes/${START_FLINK_YARN_SESSION_METADATA_KEY}")"
+    start_flink_yarn_session="${start_flink_yarn_session:-${START_FLINK_YARN_SESSION_DEFAULT}}"
+  else
+    # We only start a session on the primary master.
+    start_flink_yarn_session='false'
+  fi
 
   # Apply Flink settings by appending them to the default config
   cat << EOF >> ${FLINK_INSTALL_DIR}/conf/flink-conf.yaml
@@ -112,14 +119,10 @@ EOF
 
 function main() {
 local role="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
-local hostname="$(hostname)"
-local master_name="$(/usr/share/google/get_metadata_value attributes/dataproc-master)"
-if [[ "${role}" == 'Master' && "${hostname}" == "${master_name}" ]]; then
+if [[ "${role}" == 'Master' ]] ; then
   apt-get install -y flink
   configure_flink
 fi
 }
 
 main
-
-set +x +e


### PR DESCRIPTION
The Flink init action currently installs Flink on all masters and attempts to start a YARN session on all masters. Because this default session is configured to consume all cluster resources, all but one of the master init actions hang indefinitely while trying to allocate containers.

This change only installs and runs Flink on the primary master.