### PR TITLE
Update README with single node information

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ This repository presently offers the following actions for use with Cloud Datapr
   * Share a [Google Cloud SQL](https://cloud.google.com/sql/) Hive Metastore
   * Setup [Google Stackdriver](https://cloud.google.com/stackdriver/) monitoring for a cluster
 
+## Initialization actions on single node clusters
+
+[Single Node clusters](https://cloud.google.com/dataproc/docs/concepts/single-node-clusters) always have their dataproc-role set to `Master`. Most of the initialization actions in this repository should work out of the box, as they run only on the master. Examples include notebooks (such as Apache Zeppelin) and libraries (such as Apache Tez). Actions that run on all nodes of the cluster (such as cloud-sql-proxy) similarly work out of the box.
+
+Some initialization actions are known **not to work** on Single Node clusters. All of these expect to have daemons on multiple nodes.
+
+* Apache Drill
+* Apache Flink
+* Apache Kafka
+* Presto
+* Apache Zookeeper
+
+Feel free to send pull requests or file issues if you have a good use case for running one of these actions on a Single Node cluster.
+
 ## For more information
 For more information, review the [Cloud Dataproc documentation](https://cloud.google.com/dataproc/init-actions). You can also pose questions to the [Stack Overflow](http://www.stackoverflow.com) community with the tag `google-cloud-dataproc`.
 See our other [Google Cloud Platform github

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This repository presently offers the following actions for use with Cloud Datapr
 
 ## Initialization actions on single node clusters
 
-[Single Node clusters](https://cloud.google.com/dataproc/docs/concepts/single-node-clusters) always have their dataproc-role set to `Master`. Most of the initialization actions in this repository should work out of the box, as they run only on the master. Examples include notebooks (such as Apache Zeppelin) and libraries (such as Apache Tez). Actions that run on all nodes of the cluster (such as cloud-sql-proxy) similarly work out of the box.
+[Single Node clusters](https://cloud.google.com/dataproc/docs/concepts/single-node-clusters) have `dataproc-role` set to `Master` and `dataproc-worker-count` set to `0`. Most of the initialization actions in this repository should work out of the box, as they run only on the master. Examples include notebooks (such as Apache Zeppelin) and libraries (such as Apache Tez). Actions that run on all nodes of the cluster (such as cloud-sql-proxy) similarly work out of the box.
 
 Some initialization actions are known **not to work** on Single Node clusters. All of these expect to have daemons on multiple nodes.
 


### PR DESCRIPTION
Importantly, document init actions that do not work on single node clusters.