### PR TITLE
Fixes to oozie and hue init actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ This repository presently offers the following actions for use with Cloud Datapr
   * Share a [Google Cloud SQL](https://cloud.google.com/sql/) Hive Metastore
   * Setup [Google Stackdriver](https://cloud.google.com/stackdriver/) monitoring for a cluster
 
+## Initialization actions on single node clusters
+
+[Single Node clusters](https://cloud.google.com/dataproc/docs/concepts/single-node-clusters) have `dataproc-role` set to `Master` and `dataproc-worker-count` set to `0`. Most of the initialization actions in this repository should work out of the box, as they run only on the master. Examples include notebooks (such as Apache Zeppelin) and libraries (such as Apache Tez). Actions that run on all nodes of the cluster (such as cloud-sql-proxy) similarly work out of the box.
+
+Some initialization actions are known **not to work** on Single Node clusters. All of these expect to have daemons on multiple nodes.
+
+* Apache Drill
+* Apache Flink
+* Apache Kafka
+* Presto
+* Apache Zookeeper
+
+Feel free to send pull requests or file issues if you have a good use case for running one of these actions on a Single Node cluster.
+
 ## For more information
 For more information, review the [Cloud Dataproc documentation](https://cloud.google.com/dataproc/init-actions). You can also pose questions to the [Stack Overflow](http://www.stackoverflow.com) community with the tag `google-cloud-dataproc`.
 See our other [Google Cloud Platform github

--- a/hue/hue.sh
+++ b/hue/hue.sh
@@ -17,12 +17,12 @@ set -x -e
 # Determine the role of this node
 ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 
-
 # Only run on the master node of the cluster
 if [[ "${ROLE}" != 'Master' ]]; then
   set +x +e
   exit 0
 fi
+
 # Install hue
 apt-get update
 apt-get install -t jessie-backports hue -y
@@ -78,9 +78,6 @@ sed -i '0,/resourcemanager_api_url/! s/resourcemanager_api_url/## resourcemanage
 # Clean up temporary fles
 rm -rf hdfs-site-patch.xml core-site-patch.xml hue-patch.ini
 
-# Restart HDFS, yarn resource manager
-systemctl restart hadoop-hdfs-namenode hadoop-yarn-resourcemanager
-
 # Make hive warehouse directory
 hdfs dfs -mkdir /user/hive/warehouse
 
@@ -110,7 +107,7 @@ systemctl restart hue mysql
 /usr/lib/hue/build/env/bin/hue syncdb --noinput
 /usr/lib/hue/build/env/bin/hue migrate
 
-# Restart hue, mysql
-systemctl restart hue mysql
+# Restart servers
+systemctl restart hadoop-hdfs-namenode hadoop-yarn-resourcemanager hue mysql
 
 set +x +e

--- a/hue/hue.sh
+++ b/hue/hue.sh
@@ -68,6 +68,28 @@ cat >> /etc/hue/conf/hue.ini <<EOF
   hadoop_mapred_home=/usr/lib/hadoop-mapreduce
 EOF
 
+# If oozie installed, add hue as proxy user for oozie
+if [ -f /etc/oozie/conf/oozie-site.xml ]
+then
+	cat > oozie-site-patch.xml <<EOF
+<property>
+  <name>oozie.service.ProxyUserService.proxyuser.hue.hosts</name>
+  <value>*</value>
+</property>
+
+<property>
+  <name>oozie.service.ProxyUserService.proxyuser.hue.groups</name>
+  <value>*</value>
+</property>
+EOF
+
+	sed -i '/<\/configuration>/e cat oozie-site-patch.xml' \
+		  /etc/oozie/conf/oozie-site.xml
+
+  rm -rf oozie-site-patch.xml
+  systemctl restart oozie
+fi
+
 # Fix webhdfs_url
 OLD_HDFS_URL='## webhdfs_url\=http:\/\/localhost:50070'
 NEW_HDFS_URL='webhdfs_url\=http:\/\/'"$(hdfs getconf -confKey  dfs.namenode.http-address)"

--- a/hue/hue.sh
+++ b/hue/hue.sh
@@ -69,9 +69,9 @@ cat >> /etc/hue/conf/hue.ini <<EOF
 EOF
 
 # If oozie installed, add hue as proxy user for oozie
-if [ -f /etc/oozie/conf/oozie-site.xml ]
+if [[ -f /etc/oozie/conf/oozie-site.xml ]];
 then
-	cat > oozie-site-patch.xml <<EOF
+  cat > oozie-site-patch.xml <<EOF
 <property>
   <name>oozie.service.ProxyUserService.proxyuser.hue.hosts</name>
   <value>*</value>
@@ -83,8 +83,8 @@ then
 </property>
 EOF
 
-	sed -i '/<\/configuration>/e cat oozie-site-patch.xml' \
-		  /etc/oozie/conf/oozie-site.xml
+  sed -i '/<\/configuration>/e cat oozie-site-patch.xml' \
+      /etc/oozie/conf/oozie-site.xml
 
   rm oozie-site-patch.xml
   systemctl restart oozie

--- a/hue/hue.sh
+++ b/hue/hue.sh
@@ -86,7 +86,7 @@ EOF
 	sed -i '/<\/configuration>/e cat oozie-site-patch.xml' \
 		  /etc/oozie/conf/oozie-site.xml
 
-  rm -rf oozie-site-patch.xml
+  rm oozie-site-patch.xml
   systemctl restart oozie
 fi
 

--- a/hue/hue.sh
+++ b/hue/hue.sh
@@ -19,106 +19,98 @@ ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 
 
 # Only run on the master node of the cluster
-if [[ "${ROLE}" == 'Master' ]]; then
-  # Install hue
-  apt-get update
-  apt-get install -t jessie-backports hue-common -y
-  apt-get install hue -y
-
-  cat > core-site-patch.xml <<EOF
-  <property>
-    <name>hadoop.proxyuser.hue.hosts</name>
-    <value>*</value>
-  </property>
-  <property>
-    <name>hadoop.proxyuser.hue.groups</name>
-    <value>*</value>
-  </property>
-EOF
-  sed -i '/<\/configuration>/e cat core-site-patch.xml' \
-     /etc/hadoop/conf/core-site.xml
-
-
-  cat > hdfs-site-patch.xml <<EOF
-  <property>/ha
-    <name>dfs.webhdfs.enabled</name>
-    <value>true</value>
-  </property>
-
-  <property>
-    <name>hadoop.proxyuser.hue.hosts</name>
-    <value>*</value>
-  </property>
-
-  <property>
-    <name>hadoop.proxyuser.hue.groups</name>
-    <value>*</value>
-  </property>
-EOF
-
-  sed -i '/<\/configuration>/e cat hdfs-site-patch.xml' \
-       /etc/hadoop/conf/hdfs-site.xml
-
-  cat >> /etc/hue/conf/hue.ini <<EOF
-    # Defaults to $HADOOP_MR1_HOME or /usr/lib/hadoop-0.20-mapreduce
-    hadoop_mapred_home=/usr/lib/hadoop-mapreduce
-EOF
-
-  # Fix webhdfs_url
-  sed -i 's/## webhdfs_url\=http:\/\/localhost:50070/webhdfs_url\=http:\/\/'"$(hdfs getconf -confKey  dfs.namenode.http-address)"'/' /etc/hue/conf/hue.ini
-
-  # Uncomment every line containing localhost, replacing localhost with the fully qualified domain name.
-  sed -i "s/#*\([^#]*=.*\)localhost/\1$(hostname --fqdn)/" /etc/hue/conf/hue.ini
-
-  # Comment out any duplicate resourcemanager_api_url fields after the first one
-  sed -i '0,/resourcemanager_api_url/! s/resourcemanager_api_url/## resourcemanager_api_url/' /etc/hue/conf/hue.ini
-
-  # Clean up temporary fles
-  rm -rf hdfs-site-patch.xml core-site-patch.xml hue-patch.ini
-
-  # Restart HDFS
-  service hadoop-hdfs-namenode restart
-
-  # Make hive warehouse directory
-  hdfs dfs -mkdir /user/hive/warehouse
-
-  # Restart yarn resourcemanager
-  service hadoop-yarn-resourcemanager restart
-
-  # Configure Desktop Database to use mysql
-  perl -i -0777 -pe 's/## engine=sqlite3(\s+)## host=(\s+)## port=(\s+)## user=(\s+)## password=/engine=mysql$1host=127.0.0.1$2port=3306$3user=hue$4password=hue-password/' /etc/hue/conf/hue.ini
-
-  # Comment out sqlite3 configuration
-  sed -i 's/engine=sqlite3/## engine=sqlite3/' /etc/hue/conf/hue.ini
-
-  # Set database name to hue
-  sed -i 's/name=\/var\/lib\/hue\/desktop.db/name=hue/' /etc/hue/conf/hue.ini
-
-  # Restart Hue
-  service hue restart
-
-  # Export passwords
-  export MYSQL_PASSWORD='root-password'
-  export HUE_PASSWORD='hue-password'
-
-  # Create database, give hue user permissions
-  mysql -u root -proot-password -e " \
-    CREATE DATABASE hue; \
-    CREATE USER 'hue'@'localhost' IDENTIFIED BY '$HUE_PASSWORD'; \
-    GRANT ALL PRIVILEGES ON hue.* TO 'hue'@'localhost';"
-
-  # Restart mysql server
-  service mysql restart
-
-  # Hue creates all needed tables
-  /usr/lib/hue/build/env/bin/hue syncdb --noinput
-  /usr/lib/hue/build/env/bin/hue migrate
-
-  # Restart mysql
-  service mysql restart
-
-  # Restart Hue
-  service hue restart
+if [[ "${ROLE}" != 'Master' ]]; then
+  set +x +e
+  exit 0
 fi
+# Install hue
+apt-get update
+apt-get install -t jessie-backports hue -y
+
+cat > core-site-patch.xml <<EOF
+<property>
+  <name>hadoop.proxyuser.hue.hosts</name>
+  <value>*</value>
+</property>
+<property>
+  <name>hadoop.proxyuser.hue.groups</name>
+  <value>*</value>
+</property>
+EOF
+sed -i '/<\/configuration>/e cat core-site-patch.xml' \
+   /etc/hadoop/conf/core-site.xml
+
+
+cat > hdfs-site-patch.xml <<EOF
+<property>
+  <name>dfs.webhdfs.enabled</name>
+  <value>true</value>
+</property>
+
+<property>
+  <name>hadoop.proxyuser.hue.hosts</name>
+  <value>*</value>
+</property>
+
+<property>
+  <name>hadoop.proxyuser.hue.groups</name>
+  <value>*</value>
+</property>
+EOF
+
+sed -i '/<\/configuration>/e cat hdfs-site-patch.xml' \
+     /etc/hadoop/conf/hdfs-site.xml
+
+cat >> /etc/hue/conf/hue.ini <<EOF
+  # Defaults to $HADOOP_MR1_HOME or /usr/lib/hadoop-0.20-mapreduce
+  hadoop_mapred_home=/usr/lib/hadoop-mapreduce
+EOF
+
+# Fix webhdfs_url
+sed -i 's/## webhdfs_url\=http:\/\/localhost:50070/webhdfs_url\=http:\/\/'"$(hdfs getconf -confKey  dfs.namenode.http-address)"'/' /etc/hue/conf/hue.ini
+
+# Uncomment every line containing localhost, replacing localhost with the fully qualified domain name.
+sed -i "s/#*\([^#]*=.*\)localhost/\1$(hostname --fqdn)/" /etc/hue/conf/hue.ini
+
+# Comment out any duplicate resourcemanager_api_url fields after the first one
+sed -i '0,/resourcemanager_api_url/! s/resourcemanager_api_url/## resourcemanager_api_url/' /etc/hue/conf/hue.ini
+
+# Clean up temporary fles
+rm -rf hdfs-site-patch.xml core-site-patch.xml hue-patch.ini
+
+# Restart HDFS, yarn resource manager
+systemctl restart hadoop-hdfs-namenode hadoop-yarn-resourcemanager
+
+# Make hive warehouse directory
+hdfs dfs -mkdir /user/hive/warehouse
+
+# Configure Desktop Database to use mysql
+perl -i -0777 -pe 's/## engine=sqlite3(\s+)## host=(\s+)## port=(\s+)## user=(\s+)## password=/engine=mysql$1host=127.0.0.1$2port=3306$3user=hue$4password=hue-password/' /etc/hue/conf/hue.ini
+
+# Comment out sqlite3 configuration
+sed -i 's/engine=sqlite3/## engine=sqlite3/' /etc/hue/conf/hue.ini
+
+# Set database name to hue
+sed -i 's/name=\/var\/lib\/hue\/desktop.db/name=hue/' /etc/hue/conf/hue.ini
+
+# Export passwords
+export MYSQL_PASSWORD='root-password'
+export HUE_PASSWORD='hue-password'
+
+# Create database, give hue user permissions
+mysql -u root -proot-password -e " \
+  CREATE DATABASE hue; \
+  CREATE USER 'hue'@'localhost' IDENTIFIED BY '$HUE_PASSWORD'; \
+  GRANT ALL PRIVILEGES ON hue.* TO 'hue'@'localhost';"
+
+# Restart hue, mysql
+systemctl restart hue mysql
+
+# Hue creates all needed tables
+/usr/lib/hue/build/env/bin/hue syncdb --noinput
+/usr/lib/hue/build/env/bin/hue migrate
+
+# Restart hue, mysql
+systemctl restart hue mysql
 
 set +x +e

--- a/oozie/oozie.sh
+++ b/oozie/oozie.sh
@@ -30,20 +30,21 @@ ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 
 # Only run on the master node of the cluster
 if [[ "${ROLE}" == 'Master' ]]; then
+
   # Upgrade the repository and install Oozie
   apt-get update
   apt-get install oozie oozie-client -y
-  
+
   # The ext library is needed to enable the Oozie web console
   wget http://archive.cloudera.com/gplextras/misc/ext-2.2.zip
   unzip ext-2.2.zip
-  cp -ax ext-2.2 /usr/lib/oozie/libext/
-  
+  cp -ax ext-2.2 /var/lib/oozie/ext-2.2
+
   # Create the Oozie database
   sudo -u oozie /usr/lib/oozie/bin/ooziedb.sh create -run
-  
+
   # Hadoop must allow impersonation for Oozie to work properly
-  cat > core-site-patch.xml <<EOF
+  cat > core-site-patch.xml <<'EOF'
   <property>
     <name>hadoop.proxyuser.oozie.hosts</name>
     <value>*</value>
@@ -58,15 +59,21 @@ if [[ "${ROLE}" == 'Master' ]]; then
   </property>
   <property>
     <name>hadoop.proxyuser.${user.name}.groups</name>
-	<value>*</value>
+    <value>*</value>
   </property>
 EOF
   sed -i '/<\/configuration>/e cat core-site-patch.xml' \
-	  /etc/hadoop/conf/core-site.xml
-  
+    /etc/hadoop/conf/core-site.xml
+
+  # Install share lib
+  tar -xvzf /usr/lib/oozie/oozie-sharelib.tar.gz
+  cp -ax share /usr/lib/oozie/
+  hadoop fs -mkdir -p /user/oozie/
+  hadoop fs -put share/ /user/oozie/
+
   # Clean up temporary fles
-  rm -rf ext-2.2 ext-2.2.zip core-site-patch.xml
-  
+  rm -rf ext-2.2 ext-2.2.zip core-site-patch.xml share oozie-sharelib.tar.gz
+
   # HDFS and MapReduce must be cycled; restart to clean things up
-  reboot
+  systemctl restart hadoop-hdfs-namenode
 fi


### PR DESCRIPTION
In hue init action: add hue as proxy user for oozie if oozie is installed
In oozie init action: change where ext library installed, install share lib, get rid of reboot, other small fixes
Depends on bigtop change in latest release