### PR TITLE
Only store Jupyter notebooks in GCS.

### DIFF
--- a/jupyter/README.MD
+++ b/jupyter/README.MD
@@ -55,7 +55,7 @@ gcloud dataproc clusters create my-dataproc-cluster \
   - configures `jupyter` to use auth token `JUPYTER_AUTH_TOKEN`, with a default of none.
       - Dataproc does not recommend opening firewall ports to access Jupyter, but rather using a proxy. See [connecting to web interfaces](https://cloud.google.com/dataproc/docs/concepts/cluster-web-interfaces)
       - This proxy access is automated by [launch-jupyter-interfaces.sh](#launch-jupyter-interfacesh).
-  - targets a default notebooks directory `/root/notebooks`, into which the directory found at `gs://$DATAPROC_BUCKET/notebooks/` is copied, where `$DATAPROC_BUCKET` is the value stored in the metadata key `dataproc-bucket` (set by default upon cluster creation and overridable)
+  - loads and saves notebooks to `gs://$DATAPROC_BUCKET/notebooks/`, where `$DATAPROC_BUCKET` is the value stored in the metadata key `dataproc-bucket` (set by default upon cluster creation and overridable). Note that all clusters sharing a $DATAPROC_BUCKET will share notebooks.
   - launches the `jupyter notebook` process
 
 **NOTE**: to be run as an init action.

--- a/jupyter/internal/setup-jupyter-kernel.sh
+++ b/jupyter/internal/setup-jupyter-kernel.sh
@@ -6,7 +6,7 @@ DIR="${BASH_SOURCE%/*}"
 source "$DIR/../../util/utils.sh"
 
 ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
-JUPYTER_NOTEBOOK_DIR="/root/notebooks"
+DATAPROC_BUCKET=$(curl -f -s -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/dataproc-bucket)
 JUPYTER_PORT=$(/usr/share/google/get_metadata_value attributes/JUPYTER_PORT || true)
 [[ ! $JUPYTER_PORT =~ ^[0-9]+$ ]] && JUPYTER_PORT=8123
 JUPYTER_AUTH_TOKEN=$(/usr/share/google/get_metadata_value attributes/JUPYTER_AUTH_TOKEN || true)
@@ -14,16 +14,15 @@ JUPYTER_IP=*
 
 [[ "${ROLE}" != 'Master' ]] && throw "$0 should only be run on the Master node!"
 
-echo "Creating notebook directory $JUPYTER_NOTEBOOK_DIR if necessary..."
-[[ ! -d $JUPYTER_NOTEBOOK_DIR ]] && mkdir -p $JUPYTER_NOTEBOOK_DIR
-
 echo "Creating Jupyter config..."
 jupyter notebook --allow-root --generate-config -y --ip=127.0.0.1
 echo "c.Application.log_level = 'DEBUG'" >> ~/.jupyter/jupyter_notebook_config.py
 echo "c.NotebookApp.ip = '*'" >> ~/.jupyter/jupyter_notebook_config.py
 echo "c.NotebookApp.open_browser = False" >> ~/.jupyter/jupyter_notebook_config.py
 echo "c.NotebookApp.port = $JUPYTER_PORT" >> ~/.jupyter/jupyter_notebook_config.py
-echo "c.NotebookApp.notebook_dir = '$JUPYTER_NOTEBOOK_DIR'" >> ~/.jupyter/jupyter_notebook_config.py
+echo "c.NotebookApp.contents_manager_class = 'jgscm.GoogleStorageContentManager'" >> ~/.jupyter/jupyter_notebook_config.py
+# Must not include gs://
+echo "c.GoogleStorageContentManager.default_path = '$DATAPROC_BUCKET/notebooks'" >> ~/.jupyter/jupyter_notebook_config.py
 echo "c.NotebookApp.token = u'$JUPYTER_AUTH_TOKEN'" >> ~/.jupyter/jupyter_notebook_config.py
 
 echo "Installing pyspark Kernel..."

--- a/jupyter/internal/setup-jupyter-kernel.sh
+++ b/jupyter/internal/setup-jupyter-kernel.sh
@@ -16,7 +16,7 @@ JUPYTER_IP=*
 
 # Must not include gs:// and must exist
 NOTEBOOK_DIR="$DATAPROC_BUCKET/notebooks"
-hadoop fs -mkdir "gs://$NOTEBOOK_DIR" || true
+hadoop fs -mkdir -p "gs://$NOTEBOOK_DIR"
 
 echo "Creating Jupyter config..."
 jupyter notebook --allow-root --generate-config -y --ip=127.0.0.1

--- a/jupyter/internal/setup-jupyter-kernel.sh
+++ b/jupyter/internal/setup-jupyter-kernel.sh
@@ -14,6 +14,10 @@ JUPYTER_IP=*
 
 [[ "${ROLE}" != 'Master' ]] && throw "$0 should only be run on the Master node!"
 
+# Must not include gs:// and must exist
+NOTEBOOK_DIR="$DATAPROC_BUCKET/notebooks"
+hadoop fs -mkdir "gs://$NOTEBOOK_DIR" || true
+
 echo "Creating Jupyter config..."
 jupyter notebook --allow-root --generate-config -y --ip=127.0.0.1
 echo "c.Application.log_level = 'DEBUG'" >> ~/.jupyter/jupyter_notebook_config.py
@@ -21,8 +25,7 @@ echo "c.NotebookApp.ip = '*'" >> ~/.jupyter/jupyter_notebook_config.py
 echo "c.NotebookApp.open_browser = False" >> ~/.jupyter/jupyter_notebook_config.py
 echo "c.NotebookApp.port = $JUPYTER_PORT" >> ~/.jupyter/jupyter_notebook_config.py
 echo "c.NotebookApp.contents_manager_class = 'jgscm.GoogleStorageContentManager'" >> ~/.jupyter/jupyter_notebook_config.py
-# Must not include gs://
-echo "c.GoogleStorageContentManager.default_path = '$DATAPROC_BUCKET/notebooks'" >> ~/.jupyter/jupyter_notebook_config.py
+echo "c.GoogleStorageContentManager.default_path = '$NOTEBOOK_DIR'" >> ~/.jupyter/jupyter_notebook_config.py
 echo "c.NotebookApp.token = u'$JUPYTER_AUTH_TOKEN'" >> ~/.jupyter/jupyter_notebook_config.py
 
 echo "Installing pyspark Kernel..."

--- a/jupyter/jupyter.sh
+++ b/jupyter/jupyter.sh
@@ -6,7 +6,6 @@ INIT_ACTIONS_REPO=$(curl -f -s -H Metadata-Flavor:Google http://metadata/compute
 INIT_ACTIONS_REPO="${INIT_ACTIONS_REPO:-https://github.com/GoogleCloudPlatform/dataproc-initialization-actions.git}"
 INIT_ACTIONS_BRANCH=$(curl -f -s -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/INIT_ACTIONS_BRANCH || true)
 INIT_ACTIONS_BRANCH="${INIT_ACTIONS_BRANCH:-master}"
-DATAPROC_BUCKET=$(curl -f -s -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/dataproc-bucket)
 
 # Colon-separated list of conda channels to add before installing packages
 JUPYTER_CONDA_CHANNELS=$(curl -f -s -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/JUPYTER_CONDA_CHANNELS || true)
@@ -32,10 +31,10 @@ fi
 
 if [[ "${ROLE}" == 'Master' ]]; then
     conda install jupyter
-    if gsutil -q stat "gs://$DATAPROC_BUCKET/notebooks/**"; then
-        echo "Pulling notebooks directory to cluster master node..."
-        gsutil -m cp -r gs://$DATAPROC_BUCKET/notebooks /root/
-    fi
+
+    # For storing notebooks on GCS
+    pip install jgscm
+
     ./dataproc-initialization-actions/jupyter/internal/setup-jupyter-kernel.sh
     ./dataproc-initialization-actions/jupyter/internal/launch-jupyter-kernel.sh
 fi

--- a/jupyter/jupyter.sh
+++ b/jupyter/jupyter.sh
@@ -32,8 +32,8 @@ fi
 if [[ "${ROLE}" == 'Master' ]]; then
     conda install jupyter
 
-    # For storing notebooks on GCS
-    pip install jgscm
+    # For storing notebooks on GCS. Pin version to make this script hermetic.
+    pip install jgscm==0.1.7
 
     ./dataproc-initialization-actions/jupyter/internal/setup-jupyter-kernel.sh
     ./dataproc-initialization-actions/jupyter/internal/launch-jupyter-kernel.sh


### PR DESCRIPTION
This is a counterproposal to #154 (cc @waltherg). Instead of copying the files back and forth to GCS, just use this [cool project](https://github.com/src-d/jgscm) to read/save files directly in GCS.

CC @vmarkovtsev as the maintainer of jgscm. You mention that jgscm is in in alpha state -- I just want to check whether you have any concerns about this PR. For what it's worth, at least Python3 "hello world" worked for me.