### PR TITLE
Fix flink init action (#155)

### DIFF
--- a/flink/flink.sh
+++ b/flink/flink.sh
@@ -84,8 +84,9 @@ function configure_flink() {
   local start_flink_yarn_session
   if [[ "${hostname}" == "${master_hostname}" ]] ; then
     # Determine whether to start a detached session.
-    start_flink_yarn_session="$(/usr/share/google/get_metadata_value "attributes/${START_FLINK_YARN_SESSION_METADATA_KEY}")"
-    start_flink_yarn_session="${start_flink_yarn_session:-${START_FLINK_YARN_SESSION_DEFAULT}}"
+    start_flink_yarn_session="$(/usr/share/google/get_metadata_value \
+      "attributes/${START_FLINK_YARN_SESSION_METADATA_KEY}" || \
+      echo "${START_FLINK_YARN_SESSION_DEFAULT}")"
   else
     # We only start a session on the primary master.
     start_flink_yarn_session='false'


### PR DESCRIPTION
The init action uses `set -e` to fail if any setup actions fail (i.e., exit non-zero). The script used to fetch metadata exits non-zero if the attribute requested does not exist. We use a metadata attribute to determine whether to start a detached yarn session. This causes the init action to fail if the special attribute is not set (the default behavior).