### PR TITLE
tez-ui.sh, update nodejs to v8

### DIFF
--- a/tez/tez.sh
+++ b/tez/tez.sh
@@ -33,7 +33,8 @@ sudo sed -i '\#CLASSPATH=.*/etc/hive/conf#d' /etc/spark/conf/spark-env.sh
 if [[ "${role}" == 'Master' ]]; then
   # Install Tez and YARN Application Timeline Server.
   # Install node/npm to run HTTP server for Tez UI.
-  apt-get install tez hadoop-yarn-timelineserver nodejs-legacy npm -y
+  curl -sL https://deb.nodesource.com/setup_8.x | bash -
+  apt-get install tez hadoop-yarn-timelineserver nodejs -y
 
   # Stage Tez
   hadoop fs -mkdir -p ${tez_hdfs_path}
@@ -91,7 +92,7 @@ if [[ "${role}" == 'Master' ]]; then
   # Set up service for Tez UI on port 9999 at the path /tez-ui
   npm install -g http-server forever forever-service
   unzip /usr/lib/tez/tez-ui-*.war -d /usr/lib/tez/tez-ui
-  forever-service install tez-ui --script /usr/local/bin/http-server -o "/usr/lib/tez/ -p 9999"
+  forever-service install tez-ui --script /usr/bin/http-server -o "/usr/lib/tez/ -p 9999"
 
   # Restart daemons
 


### PR DESCRIPTION
Hello,

tez-ui won't start cause of old nodejs available in debian-jessie repos.
nodejs v0.10.x doesn't support `const`.
here is the output of `/var/log/tez-ui.log`with related error: 
```
/usr/local/lib/node_modules/http-server/node_modules/ecstatic/lib/ecstatic.js:5
const path = require('path');
^^^^^
SyntaxError: Use of const in strict mode.
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/http-server/lib/http-server.js:5:16)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
error: Forever detected script exited with code: 8
error: Script restart attempt #N
```
installing nodejs v8 fixed this.