### PR TITLE
Proposal: A simpler Jupyter init action (design review wanted)

### DIFF
--- a/jupyter/README.MD
+++ b/jupyter/README.MD
@@ -2,6 +2,8 @@
 
 This folder contains the initialization action `jupyter.sh` to quickly setup and launch [Jupyter Notebook](http://jupyter.org/), (the successor of IPython notebook) and a script to be run on the user's local machine to access the Jupyter notebook server.
 
+Note: This init action uses Conda and Python 3. Python 2 and `pip` uesrs should consider using the [jupyter2 action](https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/tree/master/jupyter2).
+
 A real-world example of how to use this from within a bash script, using the default dataproc-initialization-actions repo/branch:
 
 ```bash

--- a/jupyter2/README.md
+++ b/jupyter2/README.md
@@ -1,0 +1,27 @@
+# Jupyter Notebook
+
+This initialization action installs the latest version of [Jupyter Notebook](http://jupyter.org/) with `pip` and Python 2. Conda and Python 3 users should instead use the original [Jupyter init action](https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/tree/master/jupyter).
+
+## Usage
+
+Usage is similar to the original `jupyter` init action.
+
+```
+gcloud dataproc clusters create <cluster-name> \
+  --initialization-actions gs://dataproc-initialization-actions/jupyter2/jupyter2.sh
+```
+
+The same options are supported here:
+
+* `--bucket=gs://<some-bucket>` (the cluster staging bucket) is used for storing and retrieving notebooks. Set this to the same value when recreating clusters to share notebooks between them. By default, clusters in your project in the same region use the same bucket.
+* `--metadata JUPYTER_PORT=<some-port>` can be used to override the default port (8123)
+* `--metadata JUPYTER_AUTH_TOKEN=<some-string>` can be used to secure the notebook and ensure only users with the token can access it. See [Securing Jupyter](http://jupyter-notebook.readthedocs.io/en/stable/security.html) for more information.
+
+For example:
+
+```
+gcloud dataproc clusters create <cluster-name> \
+  --initialization-actions gs://dataproc-initialization-actions/jupyter2/jupyter2.sh \
+  --bucket gs://mybucket \
+  --metadata JUPYTER_PORT=80,JUPYTER_AUTH_TOKEN=mytoken
+```

--- a/jupyter2/jupyter2.sh
+++ b/jupyter2/jupyter2.sh
@@ -2,16 +2,14 @@
 
 set -euxo pipefail
 
-ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
-DATAPROC_BUCKET=$(curl -f -s -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/dataproc-bucket)
-JUPYTER_PORT=$(/usr/share/google/get_metadata_value attributes/JUPYTER_PORT || true)
-[[ ! $JUPYTER_PORT =~ ^[0-9]+$ ]] && JUPYTER_PORT=8123
-JUPYTER_AUTH_TOKEN=$(/usr/share/google/get_metadata_value attributes/JUPYTER_AUTH_TOKEN || true)
+readonly ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+readonly DATAPROC_BUCKET="$(/usr/share/google/get_metadata_value attributes/dataproc-bucket)"
+readonly JUPYTER_AUTH_TOKEN="$(/usr/share/google/get_metadata_value attributes/JUPYTER_AUTH_TOKEN || true)"
+readonly JUPYTER_PORT="$(/usr/share/google/get_metadata_value attributes/JUPYTER_PORT || echo 8123)"
 
-# Only run on master
-if [[ "${ROLE}" != 'Master' ]]; then
-  exit 0;
-fi
+# GCS directory in which to store notebooks.
+# DATAPROC_BUCKET must not include gs:// and bucket must exist
+readonly NOTEBOOK_DIR="${DATAPROC_BUCKET}/notebooks"
 
 function update_apt_get() {
   for ((i = 0; i < 10; i++)); do
@@ -23,18 +21,25 @@ function update_apt_get() {
   return 1
 }
 
-update_apt_get
-apt-get install -y python-dev python-tk
-easy_install pip
-pip install --upgrade jupyter jgscm matplotlib
+function err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
+  return 1
+}
 
-# Must not include gs:// and bucket must exist
-NOTEBOOK_DIR="$DATAPROC_BUCKET/notebooks"
-hadoop fs -mkdir -p "gs://$NOTEBOOK_DIR"
+function install_jupyter() {
+  apt-get install -y python-dev python-tk
+  easy_install pip
+  pip install --upgrade jupyter jgscm matplotlib
+}
 
-echo "Creating Jupyter config..."
-jupyter notebook --allow-root --generate-config -y
-cat << EOF >> ~/.jupyter/jupyter_notebook_config.py
+function configure_jupyter() {
+  # Create storage path if it does not exist
+  hadoop fs -mkdir -p "gs://${NOTEBOOK_DIR}"
+
+  echo "Creating Jupyter config..."
+  jupyter notebook --allow-root --generate-config -y
+
+  cat << EOF >> ~/.jupyter/jupyter_notebook_config.py
 
 ## Configs generated in Dataproc init action
 c.Application.log_level = 'DEBUG'
@@ -42,15 +47,17 @@ c.JupyterApp.answer_yes = True
 c.NotebookApp.ip = '*'
 c.NotebookApp.allow_root= True
 c.NotebookApp.open_browser = False
-c.NotebookApp.port = $JUPYTER_PORT
+c.NotebookApp.port = ${JUPYTER_PORT}
 c.NotebookApp.contents_manager_class = 'jgscm.GoogleStorageContentManager'
-c.GoogleStorageContentManager.default_path = '$NOTEBOOK_DIR'
-c.NotebookApp.token = u'$JUPYTER_AUTH_TOKEN'
+c.GoogleStorageContentManager.default_path = '${NOTEBOOK_DIR}'
+c.NotebookApp.token = u'${JUPYTER_AUTH_TOKEN}'
 EOF
-echo "Jupyter setup!"
 
-INIT_SCRIPT="/usr/lib/systemd/system/jupyter.service"
-cat << EOF > ${INIT_SCRIPT}
+  echo "Jupyter setup!"
+
+  local init_script="/usr/lib/systemd/system/jupyter.service"
+
+  cat << EOF > ${init_script}
 [Unit]
 Description=PySpark-based Jupyter Notebook Server
 After=hadoop-yarn-resourcemanager.service
@@ -60,16 +67,31 @@ Type=simple
 Environment=PYSPARK_DRIVER_PYTHON=jupyter
 Environment=PYSPARK_DRIVER_PYTHON_OPTS=notebook
 ExecStart=/bin/bash -c '/usr/bin/pyspark &> /var/log/jupyter_notebook.log'
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
 EOF
 
-chmod a+rw ${INIT_SCRIPT}
+  chmod a+rw ${init_script}
+}
 
-systemctl daemon-reload
-systemctl enable jupyter
-systemctl restart jupyter
-systemctl status jupyter
+function launch_jupyter() {
+  systemctl daemon-reload
+  systemctl enable jupyter
+  systemctl restart jupyter
+  systemctl status jupyter
+}
 
-echo "Jupyter installation succeeded"
+function main() {
+  if [[ "${ROLE}" == 'Master' ]]; then
+    update_apt_get || err 'Failed to update apt-get'
+    install_jupyter
+    configure_jupyter
+    launch_jupyter
+    echo "Jupyter installation succeeded"
+  fi
+}
+
+main
+

--- a/jupyter2/jupyter2.sh
+++ b/jupyter2/jupyter2.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+DATAPROC_BUCKET=$(curl -f -s -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/dataproc-bucket)
+JUPYTER_PORT=$(/usr/share/google/get_metadata_value attributes/JUPYTER_PORT || true)
+[[ ! $JUPYTER_PORT =~ ^[0-9]+$ ]] && JUPYTER_PORT=8123
+JUPYTER_AUTH_TOKEN=$(/usr/share/google/get_metadata_value attributes/JUPYTER_AUTH_TOKEN || true)
+
+# Only run on master
+if [[ "${ROLE}" != 'Master' ]]; then
+  exit 0;
+fi
+
+function update_apt_get() {
+  for ((i = 0; i < 10; i++)); do
+    if apt-get update; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+update_apt_get
+apt-get install -y python-dev python-tk
+easy_install pip
+pip install --upgrade jupyter jgscm matplotlib
+
+# Must not include gs:// and bucket must exist
+NOTEBOOK_DIR="$DATAPROC_BUCKET/notebooks"
+hadoop fs -mkdir -p "gs://$NOTEBOOK_DIR"
+
+echo "Creating Jupyter config..."
+jupyter notebook --allow-root --generate-config -y
+cat << EOF >> ~/.jupyter/jupyter_notebook_config.py
+
+## Configs generated in Dataproc init action
+c.Application.log_level = 'DEBUG'
+c.JupyterApp.answer_yes = True
+c.NotebookApp.ip = '*'
+c.NotebookApp.allow_root= True
+c.NotebookApp.open_browser = False
+c.NotebookApp.port = $JUPYTER_PORT
+c.NotebookApp.contents_manager_class = 'jgscm.GoogleStorageContentManager'
+c.GoogleStorageContentManager.default_path = '$NOTEBOOK_DIR'
+c.NotebookApp.token = u'$JUPYTER_AUTH_TOKEN'
+EOF
+echo "Jupyter setup!"
+
+INIT_SCRIPT="/usr/lib/systemd/system/jupyter.service"
+cat << EOF > ${INIT_SCRIPT}
+[Unit]
+Description=PySpark-based Jupyter Notebook Server
+After=hadoop-yarn-resourcemanager.service
+
+[Service]
+Type=simple
+Environment=PYSPARK_DRIVER_PYTHON=jupyter
+Environment=PYSPARK_DRIVER_PYTHON_OPTS=notebook
+ExecStart=/bin/bash -c '/usr/bin/pyspark &> /var/log/jupyter_notebook.log'
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+chmod a+rw ${INIT_SCRIPT}
+
+systemctl daemon-reload
+systemctl enable jupyter
+systemctl restart jupyter
+systemctl status jupyter
+
+echo "Jupyter installation succeeded"

--- a/jupyter2/jupyter2.sh
+++ b/jupyter2/jupyter2.sh
@@ -2,14 +2,21 @@
 
 set -euxo pipefail
 
-readonly ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+readonly DATAPROC_MASTER="$(/usr/share/google/get_metadata_value attributes/dataproc-master)"
 readonly DATAPROC_BUCKET="$(/usr/share/google/get_metadata_value attributes/dataproc-bucket)"
 readonly JUPYTER_AUTH_TOKEN="$(/usr/share/google/get_metadata_value attributes/JUPYTER_AUTH_TOKEN || true)"
 readonly JUPYTER_PORT="$(/usr/share/google/get_metadata_value attributes/JUPYTER_PORT || echo 8123)"
 
+# Place pyspark kernel.json file in /usr/local/share/jupyter (system-wide dir).
+# Reference: https://ipython.readthedocs.io/en/latest/install/kernel_install.html
+readonly KERNELSPEC_FILE=/usr/local/share/jupyter/kernels/pyspark/kernel.json
+
 # GCS directory in which to store notebooks.
 # DATAPROC_BUCKET must not include gs:// and bucket must exist
 readonly NOTEBOOK_DIR="${DATAPROC_BUCKET}/notebooks"
+
+# Systemd init script for jupyter
+readonly INIT_SCRIPT="/usr/lib/systemd/system/jupyter.service"
 
 function update_apt_get() {
   for ((i = 0; i < 10; i++)); do
@@ -29,7 +36,7 @@ function err() {
 function install_jupyter() {
   apt-get install -y python-dev python-tk
   easy_install pip
-  pip install --upgrade jupyter jgscm matplotlib
+  pip install --upgrade jupyter jgscm==0.1.7 matplotlib
 }
 
 function configure_jupyter() {
@@ -53,27 +60,41 @@ c.GoogleStorageContentManager.default_path = '${NOTEBOOK_DIR}'
 c.NotebookApp.token = u'${JUPYTER_AUTH_TOKEN}'
 EOF
 
-  echo "Jupyter setup!"
+  echo "Creating kernelspec"
+  mkdir -p "$(dirname ${KERNELSPEC_FILE})"
+  # {connection_file} is a magic variable that Jupyter fills in for us
+  # Note: we can only use it in argv, so cannot use env to set those
+  # environment variables.
+  cat << EOF > "${KERNELSPEC_FILE}"
+{
+ "argv": [
+    "bash",
+    "-c",
+    "PYSPARK_DRIVER_PYTHON=ipython PYSPARK_DRIVER_PYTHON_OPTS='kernel -f {connection_file}' pyspark"],
+ "display_name": "PySpark",
+ "language": "python"
+}
+EOF
+  # Ensure Jupyter has picked up the new kernel
+  jupyter kernelspec list | grep pyspark || err "Failed to create kernelspec"
 
-  local init_script="/usr/lib/systemd/system/jupyter.service"
-
-  cat << EOF > ${init_script}
+  cat << EOF > "${INIT_SCRIPT}"
 [Unit]
-Description=PySpark-based Jupyter Notebook Server
+Description=Jupyter Notebook Server
 After=hadoop-yarn-resourcemanager.service
 
 [Service]
 Type=simple
-Environment=PYSPARK_DRIVER_PYTHON=jupyter
-Environment=PYSPARK_DRIVER_PYTHON_OPTS=notebook
-ExecStart=/bin/bash -c '/usr/bin/pyspark &> /var/log/jupyter_notebook.log'
+ExecStart=/bin/bash -c 'jupyter notebook &> /var/log/jupyter_notebook.log'
 Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
 EOF
 
-  chmod a+rw ${init_script}
+  chmod a+rw "${INIT_SCRIPT}"
+
+  echo "Jupyter setup!"
 }
 
 function launch_jupyter() {
@@ -84,7 +105,8 @@ function launch_jupyter() {
 }
 
 function main() {
-  if [[ "${ROLE}" == 'Master' ]]; then
+  # In an HA cluster, only run on -m-0
+  if [[ "${HOSTNAME}" == "${DATAPROC_MASTER}" ]]; then
     update_apt_get || err 'Failed to update apt-get'
     install_jupyter
     configure_jupyter


### PR DESCRIPTION
The Jupyter init action does its job, but is a little confusing to use:

* It invokes the Conda init action(s) by git cloning this repo. It also invokes sub-scripts through this cloned copy of the repo. So any changes to the sub-scripts involve pointing the main init action script at a different git repository.
* It switches to Python 3. Because of this you lose all of the packages pre-installed by Dataproc, like `numpy`. So a script that works in `gcloud dataproc jobs submit pyspark` does not work out of the box in Jupyter. Issue #174 is an example of when this bites you.
  * Note that Jupyter comes with the `six` library, which lets you run most python 2 or 3 code against either version of python. So leaving python at python2 hopefully shouldn't be a big deal for python3 users.
* The jupyter "kernel" for pyspark does not actually invoke the `pyspark` command, so misses out on some of the configuration in `spark-env.sh`, for example. If you set `PYTHONPATH=...` in spark-env.sh, it works for pyspark, but not jupyter.

So this PR is my proposal for a simpler, one-file-only init action (credit to https://blog.sicara.com/get-started-pyspark-jupyter-guide-tutorial-ae2fe84f594f):

* Use `pip` to avoid invoking the Conda init action. Pip is probably more familiar for folks anyway. Jupyter supports installation through pip, even if it recommends using Conda.
* Stay on python2
* Use PYSPARK_DRIVER_PYTHON=jupyter. This makes Jupyter just like Zeppelin, which uses `pyspark` under the hood.
* Continues to save notebooks to GCS in the same location

Some things that my proposal does not support, but do work right now:

* `JUPYTER_CONDA_PACKAGES` to install extra packages. I do see value in this btw -- and we could support a similar flag for installing pip packages.
* Installing IPyNB extensions and RISE (turning notebooks into presentations). These both seem pretty cool, but are sort of fringe use cases that people can add if they need.
* Separate interpreters for "Python 2" and "PySpark". In my proposal, there is only an interpreter called "Python 2" that's actually just the `pyspark` shell (I'll admit that's a little confusing).
* Installing `com.databricks:spark-csv_2.10:1.3.0` for Spark < 2.0. That seems like something that should be in Dataproc itself, not in this init action.

This would obviously be a very breaking change. Maybe this should be a separate `jupyter-pyspark` init action?

I'll write a README if this looks good to all of you ( @AngusDavis @pmkc @dennishuo )