### PR TITLE
Adjust Zeppelin init action to conform the guidelines.

### DIFF
--- a/zeppelin/zeppelin.sh
+++ b/zeppelin/zeppelin.sh
@@ -97,23 +97,7 @@ function configure_zeppelin(){
     # TODO(pmkc): Add googlevis to Zeppelin Package recommendations
     apt-get install -y r-cran-googlevis
 
-## Uncomment here to compile and install 'mplot' and 'rCharts'.
-#    # Install compile dependencies
-#    apt-get install -y \
-#      r-cran-doparallel r-cran-httr r-cran-memoise r-cran-openssl \
-#      r-cran-rcurl r-cran-plyr r-cran-shiny r-cran-glmnet r-cran-data.table \
-#      libssl-dev libcurl4-openssl-dev
-#
-#    cat << EOF > install_script.r
-#options('Ncpus'=10, repos = 'http://cran.us.r-project.org')
-#install.packages('devtools')
-#require('devtools')
-## Install version 0.7.7 to avoid dependency on glmulti and RJava
-#install_version('mplot', version = '0.7.7', upgrade_dependencies = FALSE)
-#install_github('ramnathv/rCharts', upgrade_dependencies = FALSE)
-#update.packages('ggplot', ask = FALSE)
-#EOF
-#    R -f install_script.r
+    # TODO(Aniszewski): Fix SparkR (GitHub issue #198)
   fi
 }
 

--- a/zeppelin/zeppelin.sh
+++ b/zeppelin/zeppelin.sh
@@ -17,7 +17,12 @@
 # Dataproc cluster. Zeppelin is also configured based on the size of your
 # cluster and the versions of Spark/Hadoop which are installed.
 
-set -x -e
+set -euxo pipefail
+
+
+readonly ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+readonly INTERPRETER_FILE='/etc/zeppelin/conf/interpreter.json'
+readonly INIT_SCRIPT='/usr/lib/systemd/system/zeppelin-notebook.service'
 
 function update_apt_get() {
   for ((i = 0; i < 10; i++)); do
@@ -29,16 +34,19 @@ function update_apt_get() {
   return 1
 }
 
-# Only run on the master node
-ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
-INTERPRETER_FILE='/etc/zeppelin/conf/interpreter.json'
-ZEPPELIN_PORT="$(/usr/share/google/get_metadata_value attributes/zeppelin-port || true)"
+function err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
+  return 1
+}
 
-if [[ "${ROLE}" == 'Master' ]]; then
+function install_zeppelin(){
   # Install zeppelin. Don't mind if it fails to start the first time.
-  update_apt_get
   apt-get install -y -t jessie-backports zeppelin || dpkg -l zeppelin
+  if [ $? != 0 ]; then
+    err 'Failed to install zeppelin'
+  fi
 
+  # Wait up to 60s for ${INTERPRETER_FILE} to be available
   for i in {1..6}; do
     if [[ -r "${INTERPRETER_FILE}" ]]; then
       break
@@ -46,30 +54,45 @@ if [[ "${ROLE}" == 'Master' ]]; then
       sleep 10
     fi
   done
+
+  if [[ ! -r "${INTERPRETER_FILE}" ]]; then
+    err "${INTERPRETER_FILE} is missing"
+  fi
+
+  # stop service, systemd will be configured
+  service zeppelin stop
+}
+
+function configure_zeppelin(){
   # Ideally we would use Zeppelin's REST API, but it is difficult, especially
   # between versions. So sed the JSON file.
-  service zeppelin stop
+
   # Set spark.yarn.isPython to fix Zeppelin pyspark in Dataproc 1.0.
   sed -i 's/\(\s*\)"spark\.app\.name[^,}]*/&,\n\1"spark.yarn.isPython": "true"/' \
-      "${INTERPRETER_FILE}"
+    "${INTERPRETER_FILE}"
   # Unset Spark Executor memory to let the spark-defaults.conf set it.
   sed -i '/spark\.executor\.memory/d' "${INTERPRETER_FILE}"
 
   # Link in hive configuration.
   ln -s /etc/hive/conf/hive-site.xml /etc/zeppelin/conf
 
-  if [[ -n "${ZEPPELIN_PORT}" ]]; then
-    echo "export ZEPPELIN_PORT=${ZEPPELIN_PORT}" \
-        >> /etc/zeppelin/conf/zeppelin-env.sh
+  local zeppelin_port;
+  zeppelin_port="$(/usr/share/google/get_metadata_value attributes/zeppelin-port || true)"
+  if [[ -n "${zeppelin_port}" ]]; then
+    echo "export ZEPPELIN_PORT=${zeppelin_port}" \
+      >> /etc/zeppelin/conf/zeppelin-env.sh
   fi
 
   # Install R libraries and configure BigQuery for Zeppelin 0.6.1+
-  ZEPPELIN_VERSION=$(dpkg-query --showformat='${Version}' --show zeppelin)
-  if dpkg --compare-versions "${ZEPPELIN_VERSION}" '>=' 0.6.1; then
+  local zeppelin_version;
+  zeppelin_version="$(dpkg-query --showformat='${Version}' --show zeppelin)"
+  if dpkg --compare-versions "${zeppelin_version}" '>=' 0.6.1; then
     # Set BigQuery project ID if present.
-    PROJECT=$(/usr/share/google/get_metadata_value ../project/project-id)
-    sed -i "s/\(\"zeppelin.bigquery.project_id\"\)[^,}]*/\1: \"${PROJECT}\"/" \
-        "${INTERPRETER_FILE}"
+
+    local project_id;
+    project_id="$(/usr/share/google/get_metadata_value ../project/project-id)"
+    sed -i "s/\(\"zeppelin.bigquery.project_id\"\)[^,}]*/\1: \"${project_id}\"/" \
+      "${INTERPRETER_FILE}"
 
     # TODO(pmkc): Add googlevis to Zeppelin Package recommendations
     apt-get install -y r-cran-googlevis
@@ -92,7 +115,40 @@ if [[ "${ROLE}" == 'Master' ]]; then
 #EOF
 #    R -f install_script.r
   fi
+}
 
-  # Restart Zeppelin
-  service zeppelin start
-fi
+function launch_zeppelin(){
+  # Start Zeppelin as systemd job
+
+  cat << EOF > ${INIT_SCRIPT}
+[Unit]
+Description=Zeppelin Notebook
+
+[Service]
+Type=simple
+ExecStart=/usr/lib/zeppelin/bin/zeppelin-daemon.sh upstart
+ExecStop=/usr/lib/zeppelin/bin/zeppelin-daemon.sh stop
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  chmod a+rw ${INIT_SCRIPT}
+
+  systemctl daemon-reload
+  systemctl enable zeppelin-notebook
+  systemctl start zeppelin-notebook
+  systemctl status zeppelin-notebook
+}
+
+function main() {
+  if [[ "${ROLE}" == 'Master' ]]; then
+    update_apt_get || err 'Failed to update apt-get'
+    install_zeppelin
+    configure_zeppelin
+    launch_zeppelin
+  fi
+}
+
+main


### PR DESCRIPTION
As per https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/issues/190 following topics are covered:
- consistent indentation
- moved constants to top of the file
- add err function and log installation problems
- add systemd config
- main function

I'm also wondering what to do with this commented-out block of code related to `mplot` and `rCharts` . Was it ever used? It could be changed to be run only if some appropriate metadata key is set, but currently it doesn't work when uncommented.