### PR TITLE
refactored Zeppelin init action

### DIFF
--- a/zeppelin/zeppelin.sh
+++ b/zeppelin/zeppelin.sh
@@ -103,27 +103,10 @@ function configure_zeppelin(){
 
 function launch_zeppelin(){
   # Start Zeppelin as systemd job
-
-  cat << EOF > ${INIT_SCRIPT}
-[Unit]
-Description=Zeppelin Notebook
-
-[Service]
-Type=simple
-ExecStart=/usr/lib/zeppelin/bin/zeppelin-daemon.sh upstart
-ExecStop=/usr/lib/zeppelin/bin/zeppelin-daemon.sh stop
-Restart=on-failure
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-  chmod a+rw ${INIT_SCRIPT}
-
   systemctl daemon-reload
-  systemctl enable zeppelin-notebook
-  systemctl start zeppelin-notebook
-  systemctl status zeppelin-notebook
+  systemctl enable zeppelin
+  systemctl start zeppelin
+  systemctl status zeppelin
 }
 
 function main() {

--- a/zeppelin/zeppelin.sh
+++ b/zeppelin/zeppelin.sh
@@ -97,23 +97,7 @@ function configure_zeppelin(){
     # TODO(pmkc): Add googlevis to Zeppelin Package recommendations
     apt-get install -y r-cran-googlevis
 
-## Uncomment here to compile and install 'mplot' and 'rCharts'.
-#    # Install compile dependencies
-#    apt-get install -y \
-#      r-cran-doparallel r-cran-httr r-cran-memoise r-cran-openssl \
-#      r-cran-rcurl r-cran-plyr r-cran-shiny r-cran-glmnet r-cran-data.table \
-#      libssl-dev libcurl4-openssl-dev
-#
-#    cat << EOF > install_script.r
-#options('Ncpus'=10, repos = 'http://cran.us.r-project.org')
-#install.packages('devtools')
-#require('devtools')
-## Install version 0.7.7 to avoid dependency on glmulti and RJava
-#install_version('mplot', version = '0.7.7', upgrade_dependencies = FALSE)
-#install_github('ramnathv/rCharts', upgrade_dependencies = FALSE)
-#update.packages('ggplot', ask = FALSE)
-#EOF
-#    R -f install_script.r
+    # TODO(Aniszewski): Fix SparkR (GitHub issue #198)
   fi
 }
 

--- a/zeppelin/zeppelin.sh
+++ b/zeppelin/zeppelin.sh
@@ -17,7 +17,12 @@
 # Dataproc cluster. Zeppelin is also configured based on the size of your
 # cluster and the versions of Spark/Hadoop which are installed.
 
-set -x -e
+set -euxo pipefail
+
+
+readonly ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+readonly INTERPRETER_FILE='/etc/zeppelin/conf/interpreter.json'
+readonly INIT_SCRIPT='/usr/lib/systemd/system/zeppelin-notebook.service'
 
 function update_apt_get() {
   for ((i = 0; i < 10; i++)); do
@@ -29,16 +34,19 @@ function update_apt_get() {
   return 1
 }
 
-# Only run on the master node
-ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
-INTERPRETER_FILE='/etc/zeppelin/conf/interpreter.json'
-ZEPPELIN_PORT="$(/usr/share/google/get_metadata_value attributes/zeppelin-port || true)"
+function err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
+  return 1
+}
 
-if [[ "${ROLE}" == 'Master' ]]; then
+function install_zeppelin(){
   # Install zeppelin. Don't mind if it fails to start the first time.
-  update_apt_get
   apt-get install -y -t jessie-backports zeppelin || dpkg -l zeppelin
+  if [ $? != 0 ]; then
+    err 'Failed to install zeppelin'
+  fi
 
+  # Wait up to 60s for ${INTERPRETER_FILE} to be available
   for i in {1..6}; do
     if [[ -r "${INTERPRETER_FILE}" ]]; then
       break
@@ -46,30 +54,45 @@ if [[ "${ROLE}" == 'Master' ]]; then
       sleep 10
     fi
   done
+
+  if [[ ! -r "${INTERPRETER_FILE}" ]]; then
+    err "${INTERPRETER_FILE} is missing"
+  fi
+
+  # stop service, systemd will be configured
+  service zeppelin stop
+}
+
+function configure_zeppelin(){
   # Ideally we would use Zeppelin's REST API, but it is difficult, especially
   # between versions. So sed the JSON file.
-  service zeppelin stop
+
   # Set spark.yarn.isPython to fix Zeppelin pyspark in Dataproc 1.0.
   sed -i 's/\(\s*\)"spark\.app\.name[^,}]*/&,\n\1"spark.yarn.isPython": "true"/' \
-      "${INTERPRETER_FILE}"
+    "${INTERPRETER_FILE}"
   # Unset Spark Executor memory to let the spark-defaults.conf set it.
   sed -i '/spark\.executor\.memory/d' "${INTERPRETER_FILE}"
 
   # Link in hive configuration.
   ln -s /etc/hive/conf/hive-site.xml /etc/zeppelin/conf
 
-  if [[ -n "${ZEPPELIN_PORT}" ]]; then
-    echo "export ZEPPELIN_PORT=${ZEPPELIN_PORT}" \
-        >> /etc/zeppelin/conf/zeppelin-env.sh
+  local zeppelin_port;
+  zeppelin_port="$(/usr/share/google/get_metadata_value attributes/zeppelin-port || true)"
+  if [[ -n "${zeppelin_port}" ]]; then
+    echo "export ZEPPELIN_PORT=${zeppelin_port}" \
+      >> /etc/zeppelin/conf/zeppelin-env.sh
   fi
 
   # Install R libraries and configure BigQuery for Zeppelin 0.6.1+
-  ZEPPELIN_VERSION=$(dpkg-query --showformat='${Version}' --show zeppelin)
-  if dpkg --compare-versions "${ZEPPELIN_VERSION}" '>=' 0.6.1; then
+  local zeppelin_version;
+  zeppelin_version="$(dpkg-query --showformat='${Version}' --show zeppelin)"
+  if dpkg --compare-versions "${zeppelin_version}" '>=' 0.6.1; then
     # Set BigQuery project ID if present.
-    PROJECT=$(/usr/share/google/get_metadata_value ../project/project-id)
-    sed -i "s/\(\"zeppelin.bigquery.project_id\"\)[^,}]*/\1: \"${PROJECT}\"/" \
-        "${INTERPRETER_FILE}"
+
+    local project_id;
+    project_id="$(/usr/share/google/get_metadata_value ../project/project-id)"
+    sed -i "s/\(\"zeppelin.bigquery.project_id\"\)[^,}]*/\1: \"${project_id}\"/" \
+      "${INTERPRETER_FILE}"
 
     # TODO(pmkc): Add googlevis to Zeppelin Package recommendations
     apt-get install -y r-cran-googlevis
@@ -92,7 +115,40 @@ if [[ "${ROLE}" == 'Master' ]]; then
 #EOF
 #    R -f install_script.r
   fi
+}
 
-  # Restart Zeppelin
-  service zeppelin start
-fi
+function launch_zeppelin(){
+  # Start Zeppelin as systemd job
+
+  cat << EOF > ${INIT_SCRIPT}
+[Unit]
+Description=Zeppelin Notebook
+
+[Service]
+Type=simple
+ExecStart=/usr/lib/zeppelin/bin/zeppelin-daemon.sh upstart
+ExecStop=/usr/lib/zeppelin/bin/zeppelin-daemon.sh stop
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  chmod a+rw ${INIT_SCRIPT}
+
+  systemctl daemon-reload
+  systemctl enable zeppelin-notebook
+  systemctl start zeppelin-notebook
+  systemctl status zeppelin-notebook
+}
+
+function main() {
+  if [[ "${ROLE}" == 'Master' ]]; then
+    update_apt_get || err 'Failed to update apt-get'
+    install_zeppelin
+    configure_zeppelin
+    launch_zeppelin
+  fi
+}
+
+main


### PR DESCRIPTION
This PR is follow-up for #191 that was reverted in #209. As per discussion in #209 I removed additional systemd config file in favor of the one installed by apt-get.

I'm however still not sure if we should simply abandon it. The main benefit of custom `zeppelin.service` is that it contained `Restart=always` clause that is not there in the pre-installed configs. What's more it seems to be hard to change (i.e. via sed) because `Restart=no` seems to be hardcoded in sysv-generator as can be seen here: 
https://github.com/systemd/systemd/blob/master/src/sysv-generator/sysv-generator.c#L179
(it's pointig to master, but this line was the same for last 4 years ;)

I didn't find a way to change this configuration and if we want to have auto-restarting Zeppelin I'd suggest to bring back previous changes and modify them for Dataproc 1.0 on which `zeppelin-daemon.sh upstart` is not available. WDYT?

(part of #200)
