### PR TITLE
Allow to update GCS and BigQuery connectors independently

### DIFF
--- a/connectors/README.md
+++ b/connectors/README.md
@@ -27,22 +27,22 @@ will be updated, but Google Cloud Storage connector 1.7.0 and BigQuery connector
 updated together if only one of them is specified and another is not specified.
 
 For example:
- - if Google Cloud Storage connector 1.7.0 version is specified and BigQuery connector version is not
- specified, then Google Cloud Storage connector will be updated to 1.7.0 and BigQuery connector will be
- updated to 0.11.0:
-```
-gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://dataproc-initialization-actions/connectors/connectors.sh \
-    --metadata 'gcs-connector-version=1.7.0'
-```
- - if Google Cloud Storage connector 1.8.0 version is specified and BigQuery connector version is not
- specified, then only Google Cloud Storage connector will be updated and BigQuery connector will be
- left intact:
-```
-gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://dataproc-initialization-actions/connectors/connectors.sh \
-    --metadata 'gcs-connector-version=1.8.0'
-```
+* if Google Cloud Storage connector 1.7.0 version is specified and BigQuery connector version is not
+  specified, then Google Cloud Storage connector will be updated to 1.7.0 version and BigQuery connector
+  will be updated to 0.11.0 version:
+  ```
+  gcloud dataproc clusters create <CLUSTER_NAME> \
+      --initialization-actions gs://dataproc-initialization-actions/connectors/connectors.sh \
+      --metadata 'gcs-connector-version=1.7.0'
+  ```
+* if Google Cloud Storage connector 1.8.0 version is specified and BigQuery connector version is not
+  specified, then only Google Cloud Storage connector will be updated to 1.8.0 version and BigQuery
+  connector will be left intact:
+  ```
+  gcloud dataproc clusters create <CLUSTER_NAME> \
+      --initialization-actions gs://dataproc-initialization-actions/connectors/connectors.sh \
+      --metadata 'gcs-connector-version=1.8.0'
+  ```
 
 You can find more information about using initialization actions with Dataproc in the
 [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -1,32 +1,38 @@
 # Google Cloud Storage and BigQuery connectors
 
-This initialization action installs specified version of
-[Google Cloud Storage connector](https://github.com/GoogleCloudPlatform/bigdata-interop/tree/master/gcs) and updates
-[BigQuery connector](https://github.com/GoogleCloudPlatform/bigdata-interop/tree/master/bigquery)
-to the matching version from the same [release](https://github.com/GoogleCloudPlatform/bigdata-interop) on a
-[Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster.
+This initialization action installs specified versions of
+[Google Cloud Storage connector](https://github.com/GoogleCloudPlatform/bigdata-interop/tree/master/gcs)
+and [BigQuery connector](https://github.com/GoogleCloudPlatform/bigdata-interop/tree/master/bigquery)
+on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster.
 
 ## Using this initialization action
-You can use this initialization action to create a new Dataproc cluster with specific version of GCS connector installed:
+You can use this initialization action to create a new Dataproc cluster with specific version of
+Google Cloud Storage and BigQuery connector installed:
+```
+gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://dataproc-initialization-actions/connectors/connectors.sh \
+    --metadata 'gcs-connector-version=1.7.0' \
+    --metadata 'bigquery-connector-version=0.11.0'   
+```
+
+This script downloads specified version of Google Cloud Storage and BigQuery connector and deletes
+old version of these connectors.
+
+To specify connector version, find the needed released connector version on the
+[connectors releases page](https://github.com/GoogleCloudPlatform/bigdata-interop/releases),
+and set it as the `gcs-connector-version` or `bigquery-connector-version` metadata key value.
+
+If only one connector version is specified (Google Cloud Storage or Bigquery) then only this connector
+will be updated.
+
+For example, if Google Cloud Storage connector 1.7.0 version is specified and BigQuery connector version
+is not specified, then only Google Cloud Storage connector will be updated and BigQuery connector will be
+left intact:
 ```
 gcloud dataproc clusters create <CLUSTER_NAME> \
     --initialization-actions gs://dataproc-initialization-actions/connectors/connectors.sh \
     --metadata 'gcs-connector-version=1.7.0'
 ```
-
-This script downloads specified versions of GCS connector and matching version of BigQuery connector (if BigQuery connector
-was installed before) from the same [release](https://github.com/GoogleCloudPlatform/bigdata-interop/releases).
-
-To specify connector version, find the needed released GCS connector version on the
-[connectors releases page](https://github.com/GoogleCloudPlatform/bigdata-interop/releases),
-and set it as the `gcs-connector-version` metadata key value.
-
-If cluster already has BigQuery connector installed then it will be updated together with GCS connector, otherwise BigQuery
-connector will not be updated.
-
-For example, if GCS connector 1.7.0 version is specified and BigQuery connector is installed on a Dataproc cluster before
-execution of the init action then BigQuery connector will be updated to 0.11.0 version, because they are from the same
-[release](https://github.com/GoogleCloudPlatform/bigdata-interop/releases).
 
 You can find more information about using initialization actions with Dataproc in the
 [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -23,15 +23,25 @@ To specify connector version, find the needed released connector version on the
 and set it as the `gcs-connector-version` or `bigquery-connector-version` metadata key value.
 
 If only one connector version is specified (Google Cloud Storage or Bigquery) then only this connector
-will be updated.
+will be updated, but Google Cloud Storage connector 1.7.0 and BigQuery connector 0.11.0 are always
+updated together if only one of them is specified and another is not specified.
 
-For example, if Google Cloud Storage connector 1.7.0 version is specified and BigQuery connector version
-is not specified, then only Google Cloud Storage connector will be updated and BigQuery connector will be
-left intact:
+For example:
+ - if Google Cloud Storage connector 1.7.0 version is specified and BigQuery connector version is not
+ specified, then Google Cloud Storage connector will be updated to 1.7.0 and BigQuery connector will be
+ updated to 0.11.0:
 ```
 gcloud dataproc clusters create <CLUSTER_NAME> \
     --initialization-actions gs://dataproc-initialization-actions/connectors/connectors.sh \
     --metadata 'gcs-connector-version=1.7.0'
+```
+ - if Google Cloud Storage connector 1.8.0 version is specified and BigQuery connector version is not
+ specified, then only Google Cloud Storage connector will be updated and BigQuery connector will be
+ left intact:
+```
+gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://dataproc-initialization-actions/connectors/connectors.sh \
+    --metadata 'gcs-connector-version=1.8.0'
 ```
 
 You can find more information about using initialization actions with Dataproc in the

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -47,5 +47,15 @@ if [[ -z $BIGQUERY_CONNECTOR_VERSION ]] && [[ -z $GCS_CONNECTOR_VERSION ]]; then
   exit 1
 fi
 
+# because connectors from 1.7 branch are not compatible with previous connectors
+# versions (they have the same class relocation paths) we need to update both
+# of them, even if only one connector version is set
+if [[ -z $BIGQUERY_CONNECTOR_VERSION ]]  && [[ $GCS_CONNECTOR_VERSION = "1.7.0" ]]; then
+  BIGQUERY_CONNECTOR_VERSION="0.11.0"
+fi
+if [[ $BIGQUERY_CONNECTOR_VERSION = "0.11.0" ]]  && [[ -z $GCS_CONNECTOR_VERSION ]]; then
+  GCS_CONNECTOR_VERSION="1.7.0"
+fi
+
 update_connector "bigquery" "$BIGQUERY_CONNECTOR_VERSION"
 update_connector "gcs" "$GCS_CONNECTOR_VERSION"

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -20,7 +20,7 @@ validate_version() {
   local name=$1    # connector name: "bigquery" or "gcs"
   local version=$2 # connector version
   local min_valid_version=${MIN_CONNECTOR_VERSIONS[$name]}
-  if [[ $version ]] && [[ "$(min_version "$min_valid_version" "$version")" != "$min_valid_version" ]]; then
+  if [[ "$(min_version "$min_valid_version" "$version")" != "$min_valid_version" ]]; then
     echo "ERROR: $name-connector version should be greater than or equal to $min_valid_version, but was $version"
     return 1
   fi
@@ -30,7 +30,13 @@ update_connector() {
   local name=$1    # connector name: "bigquery" or "gcs"
   local version=$2 # connector version
   if [[ $version ]]; then
+    # validate new connector version
+    validate_version "${name}" "$BIGQUERY_CONNECTOR_VERSION"
+
+    # remove old connector
     rm -f "${VM_CONNECTORS_DIR}/${name}-connector-*"
+
+    # download new connector
     local path=gs://hadoop-lib/${name}/${name}-connector-${version}-hadoop2.jar
     gsutil cp "$path" "${VM_CONNECTORS_DIR}/"
   fi
@@ -40,9 +46,6 @@ if [[ -z $BIGQUERY_CONNECTOR_VERSION ]] && [[ -z $GCS_CONNECTOR_VERSION ]]; then
   echo "ERROR: None of connector versions are specified"
   exit 1
 fi
-
-validate_version "bigquery" "$BIGQUERY_CONNECTOR_VERSION"
-validate_version "gcs" "$GCS_CONNECTOR_VERSION"
 
 update_connector "bigquery" "$BIGQUERY_CONNECTOR_VERSION"
 update_connector "gcs" "$GCS_CONNECTOR_VERSION"

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -34,7 +34,7 @@ update_connector() {
     validate_version "$name" "$version"
 
     # remove old connector
-    rm -f ${VM_CONNECTORS_DIR}/${name}-connector-*
+    rm -f "${VM_CONNECTORS_DIR}/${name}-connector-"*
 
     # download new connector
     local path=gs://hadoop-lib/${name}/${name}-connector-${version}-hadoop2.jar

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -31,7 +31,7 @@ update_connector() {
   local version=$2 # connector version
   if [[ $version ]]; then
     # validate new connector version
-    validate_version "${name}" "$BIGQUERY_CONNECTOR_VERSION"
+    validate_version "$name" "$version"
 
     # remove old connector
     rm -f "${VM_CONNECTORS_DIR}/${name}-connector-*"

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -34,7 +34,7 @@ update_connector() {
     validate_version "$name" "$version"
 
     # remove old connector
-    rm -f "${VM_CONNECTORS_DIR}/${name}-connector-*"
+    rm -f ${VM_CONNECTORS_DIR}/${name}-connector-*
 
     # download new connector
     local path=gs://hadoop-lib/${name}/${name}-connector-${version}-hadoop2.jar


### PR DESCRIPTION
Starting from the next release (1.8.0/0.12.0), GCS and BigQuery connectors will be fully independent and it will be possible to mix them from different releases, that's why there no need to forcefully update both of them simultaneously.