### PR TITLE
Ganglia script review changes

### DIFF
--- a/ganglia/ganglia.sh
+++ b/ganglia/ganglia.sh
@@ -45,9 +45,9 @@ function install_ganglia() {
   ln -s /etc/ganglia-webfrontend/apache.conf /etc/apache2/sites-enabled/ganglia.conf
   sed -i "s/my cluster/${master}/" /etc/ganglia/gmetad.conf
   sed -e '/udp_send_channel {/a\  host = localhost' -i /etc/ganglia/gmond.conf
-  service ganglia-monitor restart &&
-  service gmetad restart &&
-  service apache2 restart
+  systemctl restart ganglia-monitor &&
+  systemctl restart gmetad &&
+  systemctl restart apache2
 
 }
 
@@ -60,7 +60,7 @@ function main() {
   else
     sed -e "/udp_send_channel {/a\  host = ${master}" -i /etc/ganglia/gmond.conf
     sed -i '/udp_recv_channel {/,/}/d' /etc/ganglia/gmond.conf
-    service ganglia-monitor restart
+    systemctl restart ganglia-monitor
   fi
 }
 

--- a/ganglia/ganglia.sh
+++ b/ganglia/ganglia.sh
@@ -1,19 +1,26 @@
 #!/bin/bash
-#    Copyright 2015 Google, Inc.
+#  Copyright 2015 Google, Inc.
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-#        http://www.apache.org/licenses/LICENSE-2.0
+#  http://www.apache.org/licenses/LICENSE-2.0
 #
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  This initialization action installs Ganglia.
 
 set -x -e
+
+function err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
+  return 1
+}
 
 function update_apt_get() {
   for ((i = 0; i < 10; i++)); do
@@ -25,31 +32,36 @@ function update_apt_get() {
   return 1
 }
 
-update_apt_get
-apt-get install -y ganglia-monitor
+function install_ganglia() {
+  # Install dependencies needed for ganglia
+  update_apt_get || err 'Unable to update apt-get'
+  export DEBIAN_FRONTEND=noninteractive && apt-get install -y \
+    rrdtool \
+    gmetad \
+    ganglia-webfrontend || err 'Unable to install packages'
+  sed -e "/name = \"unspecified\" /s/unspecified/${master}/" -i /etc/ganglia/gmond.conf
+  sed -e '/mcast_join /s/^  /  #/' -i /etc/ganglia/gmond.conf
+  sed -e '/bind /s/^  /  #/' -i /etc/ganglia/gmond.conf
+  ln -s /etc/ganglia-webfrontend/apache.conf /etc/apache2/sites-enabled/ganglia.conf
+  sed -i "s/my cluster/${master}/" /etc/ganglia/gmetad.conf
+  sed -e '/udp_send_channel {/a\  host = localhost' -i /etc/ganglia/gmond.conf
+  service ganglia-monitor restart &&
+  service gmetad restart &&
+  service apache2 restart
 
-MASTER=$(/usr/share/google/get_metadata_value attributes/dataproc-master)
+}
 
-sed -e "/name = \"unspecified\" /s/unspecified/$MASTER/" -i /etc/ganglia/gmond.conf
-sed -e '/mcast_join /s/^  /  #/' -i /etc/ganglia/gmond.conf
-sed -e '/bind /s/^  /  #/' -i /etc/ganglia/gmond.conf
-
-ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
-if [[ "${ROLE}" == 'Master' ]]; then
+function main() {
+  local role=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+  local master=$(/usr/share/google/get_metadata_value attributes/dataproc-master)
+  if [[ "${role}" == 'Master' ]]; then
     # Only run on the master node
-    # Install dependencies needed for ganglia
-    DEBIAN_FRONTEND=noninteractive apt install -y rrdtool gmetad ganglia-webfrontend
-    cp /etc/ganglia-webfrontend/apache.conf /etc/apache2/sites-enabled/ganglia.conf
-
-    sed -i "s/my cluster/$MASTER/" /etc/ganglia/gmetad.conf
-    sed -e '/udp_send_channel {/a\  host = localhost' -i /etc/ganglia/gmond.conf
-
-    service ganglia-monitor restart && service gmetad restart && service apache2 restart
-
-else
-
-    sed -e "/udp_send_channel {/a\  host = $MASTER" -i /etc/ganglia/gmond.conf
+    install_ganglia || err 'Ganglia install action failed'
+  else
+    sed -e "/udp_send_channel {/a\  host = ${master}" -i /etc/ganglia/gmond.conf
     sed -i '/udp_recv_channel {/,/}/d' /etc/ganglia/gmond.conf
     service ganglia-monitor restart
+  fi
+}
 
-fi
+main


### PR DESCRIPTION
Changes related to the #200 

- Added comment
- Changed spacing
- Functions extraction
- Too long lines split with \ 
- Renamed variables and moved to preferred locals
- Systemctl usage instead of service

tested on image-version '1.2.0' passed from command (not web console). For default image version initialization fails.