### PR TITLE
Drill refactor

### DIFF
--- a/drill/README.md
+++ b/drill/README.md
@@ -6,17 +6,32 @@ This initialization action installs [Apache Drill](http://drill.apache.org) on a
 
 Check the variables set in the script to ensure they're to your liking.
 
-Once you have configured a copy of this script, you can use this initialization action to create a new Dataproc cluster with Drill installed by:
+Once you have configured a copy of this script, you can use this initialization action to create a new Dataproc cluster with Drill installed by running one of the following commands depending on your desired cluster type.
 
-1. Uploading a copy of the [initialization action for zookeeper](https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/tree/master/zookeeper) to [Google Cloud Storage](https://cloud.google.com/storage).
-1. Uploading a copy of the initialization action (`drill.sh`) to GCS.
-1. Using the `gcloud` command to create a new cluster with zookeeper and this initialization action. You can skipp zookeeper.sh init action for HA configuration - already has preinstalled Zookeeper and for Single node - no worker nodes. For standard configuration it is required to first initialize Zookeeper. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
+Standard cluster (requires Zookeeper init action)
 
-    ```bash
-    gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://<GCS_BUCKET>/zookeeper.sh,gs://<GCS_BUCKET>/drill.sh
-    --initialization-action-timeout 5m
-    ```
+```bash
+gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://dataproc-initialization-actions/zookeeper/zookeeper.sh \
+    --initialization-actions gs://dataproc-initialization-actions/drill/drill.sh
+```
+
+High availability cluster (Zookeeper comes pre-installed)
+
+```bash
+gcloud dataproc clusters create <CLUSTER_NAME> \
+    --num-masters 3 \
+    --initialization-actions gs://dataproc-initialization-actions/drill/drill.sh
+```
+
+Single node cluster (Zookeeper is unnecessary)
+
+```bash
+gcloud dataproc clusters create <CLUSTER_NAME> \
+    --single-node \
+    --initialization-actions gs://dataproc-initialization-actions/drill/drill.sh
+```
+
 1. Once the cluster has been created, Drillbits will start on all nodes. You can log into any node of the cluster to run Drill queries. Drill is installed in `/usr/lib/drill` (unless you change the setting) which contains a `bin` directory with `sqlline`.
 
 You can run the following to get into sqlline, the Drill CLI query tool:

--- a/drill/README.md
+++ b/drill/README.md
@@ -36,16 +36,12 @@ Check the variables set in the script to ensure they're to your liking.
 
 You can run the following to get into sqlline, the Drill CLI query tool:
 
-`sudo -u drill /usr/lib/drill/bin/sqlline -u jdbc:drill:`
-
-If you prefer to run drill as your user, set `DRILL_YARN_LOG_DIR` to someplace you have permission to write to:
-
-`DRILL_YARN_LOG_DIR=~/logs /usr/lib/drill/bin/sqlline -u jdbc:drill:`
+`/usr/lib/drill/bin/sqlline -u jdbc:drill:`
 
 Once in sqlline, you can see what storage plugins are available. Out of the box, this initialization action supports GCS (gs), HDFS (hdfs), local linux file system (dfs) and Hive (hive):
 
 ```
-$ DRILL_YARN_LOG_DIR=~/logs /usr/lib/drill/bin/sqlline -u jdbc:drill:
+$ /usr/lib/drill/bin/sqlline -u jdbc:drill:
 OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=512M; support was removed in 8.0
 apache drill 1.9.0
 "just drill it"
@@ -71,12 +67,10 @@ apache drill 1.9.0
 
 ### On single node clusters
 
-In order to use Drill on single node cluster, run `usr/lib/drill/bin/drill-embedded` or run sqlline with zk=local: `/usr/lib/drill/bin/sqlline -u jdbc:drill:zk=local`.
-
-You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+In order to use Drill on single node cluster, run `/usr/lib/drill/bin/drill-embedded` or run sqlline with zk=local: `/usr/lib/drill/bin/sqlline -u jdbc:drill:zk=local`.
 
 ## Important notes
 * This script must be updated based on which Drill version you wish you install
 * This script must be updated based on your Cloud Dataproc cluster
-* Access to the Drill UI is possible via SSH forwarding to port 8047 on any drillbit, or with a [SOCKS proxy via SSH](https://cloud.google.com/solutions/connecting-securely#socks-proxy-over-ssh).
+* Access to the Drill UI is possible via SSH forwarding to port 8047 on any node, or with a [SOCKS proxy via SSH](https://cloud.google.com/solutions/connecting-securely#socks-proxy-over-ssh).
 * By default your Drill query profiles are stored in GCS in your cluster's dataproc bucket, as returned by `/usr/share/google/get_metadata_value attributes/dataproc-bucket`. You can change this in `drill.sh`.

--- a/drill/README.md
+++ b/drill/README.md
@@ -68,7 +68,7 @@ apache drill 1.9.0
 +---------------------+
 12 rows selected (3.943 seconds)
 ```
-In order to test Drill on single node cluster it is needed to use drill-embedded version.
+In order to test Drill on single node cluster it is needed to use usr/lib/drill/bin/drill-embedded or execute sqlline query with zk specified as local - sqlline -u jdbc:drill:zk=local.
 
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 

--- a/drill/README.md
+++ b/drill/README.md
@@ -8,29 +8,29 @@ Check the variables set in the script to ensure they're to your liking.
 
 1. Use the `gcloud` command to create a new cluster with Drill installed. Run one of the following commands depending on your desired cluster type.
 
-  Standard cluster (requires Zookeeper init action)
+    Standard cluster (requires Zookeeper init action)
 
-  ```bash
-  gcloud dataproc clusters create <CLUSTER_NAME> \
-      --initialization-actions gs://dataproc-initialization-actions/zookeeper/zookeeper.sh \
-      --initialization-actions gs://dataproc-initialization-actions/drill/drill.sh
-  ```
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+        --initialization-actions gs://dataproc-initialization-actions/zookeeper/zookeeper.sh \
+        --initialization-actions gs://dataproc-initialization-actions/drill/drill.sh
+    ```
 
-  High availability cluster (Zookeeper comes pre-installed)
+    High availability cluster (Zookeeper comes pre-installed)
 
-  ```bash
-  gcloud dataproc clusters create <CLUSTER_NAME> \
-      --num-masters 3 \
-      --initialization-actions gs://dataproc-initialization-actions/drill/drill.sh
-  ```
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+        --num-masters 3 \
+        --initialization-actions gs://dataproc-initialization-actions/drill/drill.sh
+    ```
 
-  Single node cluster (Zookeeper is unnecessary)
+    Single node cluster (Zookeeper is unnecessary)
 
-  ```bash
-  gcloud dataproc clusters create <CLUSTER_NAME> \
-      --single-node \
-      --initialization-actions gs://dataproc-initialization-actions/drill/drill.sh
-  ```
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+        --single-node \
+        --initialization-actions gs://dataproc-initialization-actions/drill/drill.sh
+    ```
 
 1. Once the cluster has been created, Drillbits will start on all nodes. You can log into any node of the cluster to run Drill queries. Drill is installed in `/usr/lib/drill` (unless you change the setting) which contains a `bin` directory with `sqlline`.
 

--- a/drill/README.md
+++ b/drill/README.md
@@ -38,14 +38,14 @@ You can run the following to get into sqlline, the Drill CLI query tool:
 
 `sudo -u drill /usr/lib/drill/bin/sqlline -u jdbc:drill:`
 
-If you prefer to run drill as your user, set `DRILL_LOG_DIR` to someplace you have permission to write to:
+If you prefer to run drill as your user, set `DRILL_YARN_LOG_DIR` to someplace you have permission to write to:
 
-`DRILL_LOG_DIR=~/logs /usr/lib/drill/bin/sqlline -u jdbc:drill:`
+`DRILL_YARN_LOG_DIR=~/logs /usr/lib/drill/bin/sqlline -u jdbc:drill:`
 
 Once in sqlline, you can see what storage plugins are available. Out of the box, this initialization action supports GCS (gs), HDFS (hdfs), local linux file system (dfs) and Hive (hive):
 
 ```
-$ DRILL_LOG_DIR=~/logs /usr/lib/drill/bin/sqlline -u jdbc:drill:
+$ DRILL_YARN_LOG_DIR=~/logs /usr/lib/drill/bin/sqlline -u jdbc:drill:
 OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=512M; support was removed in 8.0
 apache drill 1.9.0
 "just drill it"

--- a/drill/README.md
+++ b/drill/README.md
@@ -68,7 +68,10 @@ apache drill 1.9.0
 +---------------------+
 12 rows selected (3.943 seconds)
 ```
-In order to test Drill on single node cluster it is needed to use usr/lib/drill/bin/drill-embedded or execute sqlline query with zk specified as local - sqlline -u jdbc:drill:zk=local.
+
+### On single node clusters
+
+In order to use Drill on single node cluster, run `usr/lib/drill/bin/drill-embedded` or run sqlline with zk=local: `/usr/lib/drill/bin/sqlline -u jdbc:drill:zk=local`.
 
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 

--- a/drill/README.md
+++ b/drill/README.md
@@ -10,7 +10,7 @@ Once you have configured a copy of this script, you can use this initialization 
 
 1. Uploading a copy of the [initialization action for zookeeper](https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/tree/master/zookeeper) to [Google Cloud Storage](https://cloud.google.com/storage).
 1. Uploading a copy of the initialization action (`drill.sh`) to GCS.
-1. Using the `gcloud` command to create a new cluster with zookeeper and this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
+1. Using the `gcloud` command to create a new cluster with zookeeper and this initialization action. You can skipp zookeeper.sh init action for HA configuration - already has preinstalled Zookeeper and for Single node - no worker nodes. For standard configuration it is required to first initialize Zookeeper. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
@@ -53,6 +53,7 @@ apache drill 1.9.0
 +---------------------+
 12 rows selected (3.943 seconds)
 ```
+In order to test Drill on single node cluster it is needed to use drill-embedded version.
 
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 

--- a/drill/drill.sh
+++ b/drill/drill.sh
@@ -14,7 +14,7 @@ function print_err_logs() {
     echo ">>> $i"
     cat "$i";
   done
-  return 0
+  return 1
 }
 
 function create_hive_storage_plugin() {

--- a/drill/drill.sh
+++ b/drill/drill.sh
@@ -262,6 +262,8 @@ EOF
 
   chmod +rx /etc/drill/conf/*
 
+  chmod 777 /usr/lib/drill/log/
+
   start_drillbit
   # Clean up
   rm -f /tmp/*_plugin.json

--- a/drill/drill.sh
+++ b/drill/drill.sh
@@ -1,100 +1,47 @@
 #!/bin/bash
 set -x -e
 
-# where we should install drill
-DRILL_USER=drill
-DRILL_USER_HOME=/var/lib/drill
-DRILL_HOME=/usr/lib/drill
-DRILL_LOG_DIR=/var/log/drill
-DRILL_VERSION="1.9.0"
+# drill installation paths and user & version details
+readonly DRILL_USER=drill
+readonly DRILL_USER_HOME=/var/lib/drill
+readonly DRILL_HOME=/usr/lib/drill
+readonly DRILL_LOG_DIR=${DRILL_HOME}/log
+readonly DRILL_VERSION='1.13.0'
 
+function print_err_logs() {
+  for i in ${DRILL_LOG_DIR}/*;
+  do
+    echo ">>> $i"
+    cat "$i";
+  done
+  return 0
+}
 
-# Determine the role of this node
-ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
-# Determine the cluster name
-CLUSTER_NAME=$(/usr/share/google/get_metadata_value attributes/dataproc-cluster-name)
-
-# Determine the cluster uuid
-CLUSTER_UUID=$(/usr/share/google/get_metadata_value attributes/dataproc-cluster-uuid)
-
-# Change these if you have a GCS bucket you'd like to use instead.
-DATAPROC_BUCKET=$(/usr/share/google/get_metadata_value attributes/dataproc-bucket)
-
-# Use a GCS bucket for Drill profiles, partitioned by cluster name and uuid.
-PROFILE_STORE="gs://$DATAPROC_BUCKET/profiles/$CLUSTER_NAME/$CLUSTER_UUID"
-GS_PLUGIN_BUCKET="gs://$DATAPROC_BUCKET"
-
-# intelligently generate the zookeeper string
-ZOOKEEPER_CLIENT_PORT=$(grep clientPort /etc/zookeeper/conf/zoo.cfg | cut -d '=' -f 2)
-ZOOKEEPER_LIST=$(grep "^server\." /etc/zookeeper/conf/zoo.cfg | \
-        cut -d '=' -f 2 | cut -d ':' -f 1 | sed "s/$/:${ZOOKEEPER_CLIENT_PORT}/" | \
-        xargs echo | sed "s/ /,/g")
-
-# Get hive metastore thrift and HDFS URIs
-HIVEMETA=$(bdconfig get_property_value --configuration_file /etc/hive/conf/hive-site.xml --name hive.metastore.uris 2>/dev/null)
-HDFS=$(bdconfig get_property_value --configuration_file /etc/hadoop/conf/core-site.xml --name fs.default.name 2>/dev/null)
-
-# Create drill pseudo-user.
-useradd -r -m -d $DRILL_USER_HOME $DRILL_USER || echo
-
-# Create drill home
-mkdir -p $DRILL_HOME && chown $DRILL_USER:$DRILL_USER $DRILL_HOME
-
-# Download and unpack Drill as the pseudo-user.
-curl -L http://apache.mirrors.lucidnetworks.net/drill/drill-$DRILL_VERSION/apache-drill-$DRILL_VERSION.tar.gz | sudo -u $DRILL_USER tar --strip-components=1 -C $DRILL_HOME -vxzf -
-
-# Replace default configuration with cluster-specific.
-sed -i "s/drillbits1/$CLUSTER_NAME/" $DRILL_HOME/conf/drill-override.conf
-sed -i "s/localhost:2181/$ZOOKEEPER_LIST/" $DRILL_HOME/conf/drill-override.conf
-
-# Make the log directory
-mkdir -p $DRILL_LOG_DIR && chown $DRILL_USER:$DRILL_USER $DRILL_LOG_DIR
-
-# Symlink drill conf dir to /etc
-mkdir -p /etc/drill && ln -sf $DRILL_HOME/conf /etc/drill/
-
-# Point drill logs to $DRILL_LOG_DIR
-echo DRILL_LOG_DIR=$DRILL_LOG_DIR >> $DRILL_HOME/conf/drill-env.sh
-
-# Link GCS connector to drill 3rdparty jars
-ln -sf /usr/lib/hadoop/lib/gcs-connector-*.jar $DRILL_HOME/jars/3rdparty
-
-# Symlink core-site.xml to $DRILL_HOME/conf
-ln -sf /etc/hadoop/conf/core-site.xml /etc/drill/conf
-
-# Set ZK PStore to use a GCS Bucket
-# Using GCS makes all Drill profiles available from any drillbit, and also
-# persists the profiles past the lifetime of a cluster.
-cat >> $DRILL_HOME/conf/drill-override.conf <<EOF
-drill.exec: { sys.store.provider.zk.blobroot: "$PROFILE_STORE" }
-EOF
-
-(
-# Start drillbit
-sudo -u $DRILL_USER $DRILL_HOME/bin/drillbit.sh status ||\
-	sudo -u $DRILL_USER $DRILL_HOME/bin/drillbit.sh start && sleep 10
-
-# Create the hive storage plugin
-cat > /tmp/hive_plugin.json <<EOF
+function create_hive_storage_plugin() {
+  # Create the hive storage plugin
+  cat > /tmp/hive_plugin.json <<EOF
 {
 "name": "hive",
 "config": {
     "type": "hive",
     "enabled": true,
     "configProps": {
-    "hive.metastore.uris": "$HIVEMETA",
+    "hive.metastore.uris": "${HIVEMETA}",
     "hive.metastore.sasl.enabled": "false",
-    "fs.default.name": "$HDFS"
+    "fs.default.name": "${HDFS}"
     }
   }
 }
 EOF
+  curl -d@/tmp/hive_plugin.json -H 'Content-Type: application/json' -X POST http://localhost:8047/storage/hive.json
+}
 
-# Create GCS storage plugin
-cat > /tmp/gcs_plugin.json <<EOF
+function create_gcs_storage_plugin() {
+  # Create GCS storage plugin
+  cat > /tmp/gcs_plugin.json <<EOF
 {
     "config": {
-        "connection": "$GS_PLUGIN_BUCKET",
+        "connection": "${GS_PLUGIN_BUCKET}",
         "enabled": true,
         "formats": {
             "avro": {
@@ -157,12 +104,15 @@ cat > /tmp/gcs_plugin.json <<EOF
     "name": "gs"
 }
 EOF
+  curl -d@/tmp/gcs_plugin.json -H 'Content-Type: application/json' -X POST http://localhost:8047/storage/gs.json
+}
 
-# Create/Update hdfs storage plugin
-cat > /tmp/hdfs_plugin.json <<EOF
+function create_hdfs_storage_plugin() {
+  # Create/Update hdfs storage plugin
+  cat > /tmp/hdfs_plugin.json <<EOF
 {
     "config": {
-        "connection": "$HDFS",
+        "connection": "${HDFS}",
         "enabled": true,
         "formats": {
             "avro": {
@@ -230,13 +180,83 @@ cat > /tmp/hdfs_plugin.json <<EOF
     "name": "hdfs"
 }
 EOF
+  curl -d@/tmp/hdfs_plugin.json -H 'Content-Type: application/json' -X POST http://localhost:8047/storage/hdfs.json
+}
 
-curl -d@/tmp/hive_plugin.json -H "Content-Type: application/json" -X POST http://localhost:8047/storage/hive.json
-curl -d@/tmp/gcs_plugin.json -H "Content-Type: application/json" -X POST http://localhost:8047/storage/gs.json
-curl -d@/tmp/hdfs_plugin.json -H "Content-Type: application/json" -X POST http://localhost:8047/storage/hdfs.json
-) || for i in /var/log/drill/*; do echo ">>> $i"; cat "$i" ; done
+function start_drillbit() {
+  # Start drillbit
+  sudo -u ${DRILL_USER} ${DRILL_HOME}/bin/drillbit.sh status \
+    || sudo -u ${DRILL_USER} ${DRILL_HOME}/bin/drillbit.sh start && sleep 10
+  create_hive_storage_plugin
+  create_gcs_storage_plugin
+  create_hdfs_storage_plugin
+}
 
-# Clean up
-rm -f /tmp/*_plugin.json
+function main() {
+  # Determine the cluster name
+  local cluster_name=$(/usr/share/google/get_metadata_value attributes/dataproc-cluster-name)
 
-set +x +e
+  # Determine the cluster uuid
+  local cluster_uuid=$(/usr/share/google/get_metadata_value attributes/dataproc-cluster-uuid)
+
+  # Change these if you have a GCS bucket you'd like to use instead.
+  local dataproc_bucket=$(/usr/share/google/get_metadata_value attributes/dataproc-bucket)
+
+  # Use a GCS bucket for Drill profiles, partitioned by cluster name and uuid.
+  local profile_store="gs://${dataproc_bucket}/profiles/${cluster_name}/${cluster_uuid}"
+  local gs_plugin_bucket="gs://${dataproc_bucket}"
+
+  # intelligently generate the zookeeper string
+  local zookeeper_client_port=$(grep clientPort /etc/zookeeper/conf/zoo.cfg | cut -d '=' -f 2)
+  local zookeeper_list=$(grep '^server\.' /etc/zookeeper/conf/zoo.cfg \
+     | cut -d '=' -f 2 | cut -d ':' -f 1 | sed "s/$/:${zookeeper_client_port}/" \
+     | xargs echo | sed 's/ /,/g')
+
+  # Get hive metastore thrift and HDFS URIs
+  local hivemeta=$(bdconfig get_property_value \
+    --configuration_file /etc/hive/conf/hive-site.xml \
+    --name hive.metastore.uris 2>/dev/null)
+  local hdfs=$(bdconfig get_property_value \
+    --configuration_file /etc/hadoop/conf/core-site.xml \
+    --name fs.default.name 2>/dev/null)
+
+  # Create drill pseudo-user.
+  useradd -r -m -d ${DRILL_USER_HOME} ${DRILL_USER} || echo
+
+  # Create drill home
+  mkdir -p ${DRILL_HOME} && chown ${DRILL_USER}:${DRILL_USER} ${DRILL_HOME}
+
+  # Download and unpack Drill as the pseudo-user.
+  sudo wget http://apache.mirrors.hoobly.com/drill/drill-${DRILL_VERSION}/apache-drill-${DRILL_VERSION}.tar.gz
+  sudo -u ${DRILL_USER} tar -xvzf apache-drill-${DRILL_VERSION}.tar.gz -C ${DRILL_HOME} --strip 1
+
+  # Replace default configuration with cluster-specific.
+  sed -i "s/drillbits1/${cluster_name}/" ${DRILL_HOME}/conf/drill-override.conf
+  sed -i "s/localhost:2181/${zookeeper_list}/" ${DRILL_HOME}/conf/drill-override.conf
+  # Make the log directory
+  mkdir -p ${DRILL_LOG_DIR} && chown ${DRILL_USER}:${DRILL_USER} ${DRILL_LOG_DIR}
+
+  # Symlink drill conf dir to /etc
+  mkdir -p /etc/drill && ln -sf ${DRILL_HOME}/conf /etc/drill/
+
+  # Point drill logs to $DRILL_LOG_DIR
+  echo DRILL_LOG_DIR=${DRILL_LOG_DIR} >> ${DRILL_HOME}/conf/drill-env.sh
+
+  # Link GCS connector to drill 3rdparty jars
+  ln -sf /usr/lib/hadoop/lib/gcs-connector-*.jar ${DRILL_HOME}/jars/3rdparty
+
+  # Symlink core-site.xml to $DRILL_HOME/conf
+  ln -sf /etc/hadoop/conf/core-site.xml /etc/drill/conf
+
+  # Set ZK PStore to use a GCS Bucket
+  # Using GCS makes all Drill profiles available from any drillbit, and also
+  # persists the profiles past the lifetime of a cluster.
+  cat >> ${DRILL_HOME}/conf/drill-override.conf <<EOF
+drill.exec: { sys.store.provider.zk.blobroot: "${profile_store}" }
+EOF
+  # Clean up
+  rm -f /tmp/*_plugin.json
+  start_drillbit
+}
+
+main || print_err_logs

--- a/drill/drill.sh
+++ b/drill/drill.sh
@@ -258,6 +258,9 @@ function main() {
   cat >> ${DRILL_HOME}/conf/drill-override.conf <<EOF
 drill.exec: { sys.store.provider.zk.blobroot: "${profile_store}" }
 EOF
+  chown -R drill:drill /etc/drill/conf/*
+
+  chmod +rx /etc/drill/conf/*
 
   start_drillbit
   # Clean up

--- a/drill/drill.sh
+++ b/drill/drill.sh
@@ -248,6 +248,9 @@ function main() {
   # Symlink core-site.xml to $DRILL_HOME/conf
   ln -sf /etc/hadoop/conf/core-site.xml /etc/drill/conf
 
+  # Symlink hdfs-site.xml to $DRILL_HOME/conf
+  ln -sf /etc/hadoop/conf/hdfs-site.xml /etc/drill/conf
+
   # Set ZK PStore to use a GCS Bucket
   # Using GCS makes all Drill profiles available from any drillbit, and also
   # persists the profiles past the lifetime of a cluster.

--- a/drill/drill.sh
+++ b/drill/drill.sh
@@ -187,7 +187,7 @@ EOF
 function start_drillbit() {
   # Start drillbit
   sudo -u ${DRILL_USER} ${DRILL_HOME}/bin/drillbit.sh status \
-    || sudo -u ${DRILL_USER} ${DRILL_HOME}/bin/drillbit.sh start && sleep 45
+    || sudo -u ${DRILL_USER} ${DRILL_HOME}/bin/drillbit.sh start && sleep 60
   create_hive_storage_plugin
   create_gcs_storage_plugin
   create_hdfs_storage_plugin
@@ -212,7 +212,7 @@ function main() {
   local zookeeper_list=$(grep '^server\.' /etc/zookeeper/conf/zoo.cfg \
      | cut -d '=' -f 2 | cut -d ':' -f 1 | sed "s/$/:${zookeeper_client_port}/" \
      | xargs echo | sed 's/ /,/g')
-  echo "${zookeeper_list}"
+
   # Get hive metastore thrift and HDFS URIs
   local hivemeta=$(bdconfig get_property_value \
     --configuration_file /etc/hive/conf/hive-site.xml \


### PR DESCRIPTION
Review changes #200.

Original action does not allow for single, standard and HA configuration clusters - had to apply some changes to move this on. Now all clusters can be initialized but there are some issues with running drill example. Tested on drill version 1.13 and image-version 1.2.27.

Current state:

- All clusters initialize
- For init action with zookeeper first   (--initialization-actions gs://dataproc-initialization-actions/zookeeper/zookeeper.sh,gs://.../drill/drill.sh  ) Drill sample works only for single node configuration. For others there is an error: 
```
Error: Failure in starting embedded Drillbit: java.net.BindException: Address already in use (state=,code=0)
java.sql.SQLException: Failure in starting embedded Drillbit: java.net.BindException: Address already in use
        at org.apache.drill.jdbc.impl.DrillConnectionImpl.<init>(DrillConnectionImpl.java:142)
        at org.apache.drill.jdbc.impl.DrillJdbc41Factory.newDrillConnection(DrillJdbc41Factory.java:72)
        at org.apache.drill.jdbc.impl.DrillFactory.newConnection(DrillFactory.java:69)
        at org.apache.calcite.avatica.UnregisteredDriver.connect(UnregisteredDriver.java:144)
        at org.apache.drill.jdbc.Driver.connect(Driver.java:72)
        at sqlline.DatabaseConnection.connect(DatabaseConnection.java:167)
        at sqlline.DatabaseConnection.getConnection(DatabaseConnection.java:213)
        at sqlline.Commands.connect(Commands.java:1083)
        at sqlline.Commands.connect(Commands.java:1015)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at sqlline.ReflectiveCommandHandler.execute(ReflectiveCommandHandler.java:36)
        at sqlline.SqlLine.dispatch(SqlLine.java:742)
        at sqlline.SqlLine.initArgs(SqlLine.java:528)
        at sqlline.SqlLine.begin(SqlLine.java:596)
        at sqlline.SqlLine.start(SqlLine.java:375)
        at sqlline.SqlLine.main(SqlLine.java:268)
Caused by: java.net.BindException: Address already in use
        at sun.nio.ch.Net.bind0(Native Method)
        at sun.nio.ch.Net.bind(Net.java:433)
        at sun.nio.ch.Net.bind(Net.java:425)
        at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:223)
        at sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:74)
        at org.eclipse.jetty.server.ServerConnector.open(ServerConnector.java:279)
        at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:80)
        at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:218)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
        at org.eclipse.jetty.server.Server.doStart(Server.java:337)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
        at org.apache.drill.exec.server.rest.WebServer.start(WebServer.java:169)
        at org.apache.drill.exec.server.Drillbit.run(Drillbit.java:193)
        at org.apache.drill.jdbc.impl.DrillConnectionImpl.<init>(DrillConnectionImpl.java:133)
        ... 18 more
apache drill 1.12.0 
"what ever the mind of man can conceive and believe, drill can query"
0: jdbc:drill:zk=local> SELECT * FROM cp.`employee.json` LIMIT 3;
No current connection
0: jdbc:drill:zk=local> Mar 21, 2018 3:36:16 PM org.glassfish.jersey.server.ApplicationHandler initialize
INFO: Initiating Jersey application, version Jersey: 2.8 2014-04-29 01:25:26...
Error: Failure in starting embedded Drillbit: java.net.BindException: Address already in use (state=,code=0)
``` 
- For init action without zookeeper, drill samples work on single and standard configuration. For HA there is an error:
```Error: Failure in starting embedded Drillbit: java.lang.IllegalArgumentException: java.net.UnknownHostException: adamstasiak-test-13013-drill-ha (state=,code=0)
java.sql.SQLException: Failure in starting embedded Drillbit: java.lang.IllegalArgumentException: java.net.UnknownHostException: adamstasiak-test-13013-drill-ha
        at org.apache.drill.jdbc.impl.DrillConnectionImpl.<init>(DrillConnectionImpl.java:142)
        at org.apache.drill.jdbc.impl.DrillJdbc41Factory.newDrillConnection(DrillJdbc41Factory.java:72)
        at org.apache.drill.jdbc.impl.DrillFactory.newConnection(DrillFactory.java:69)
        at org.apache.calcite.avatica.UnregisteredDriver.connect(UnregisteredDriver.java:144)
        at org.apache.drill.jdbc.Driver.connect(Driver.java:72)
        at sqlline.DatabaseConnection.connect(DatabaseConnection.java:167)
        at sqlline.DatabaseConnection.getConnection(DatabaseConnection.java:213)
        at sqlline.Commands.connect(Commands.java:1083)
        at sqlline.Commands.connect(Commands.java:1015)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at sqlline.ReflectiveCommandHandler.execute(ReflectiveCommandHandler.java:36)
        at sqlline.SqlLine.dispatch(SqlLine.java:742)
        at sqlline.SqlLine.initArgs(SqlLine.java:528)
        at sqlline.SqlLine.begin(SqlLine.java:596)
        at sqlline.SqlLine.start(SqlLine.java:375)
        at sqlline.SqlLine.main(SqlLine.java:268)
Caused by: java.lang.IllegalArgumentException: java.net.UnknownHostException: adamstasiak-test-13013-drill-ha
        at org.apache.hadoop.security.SecurityUtil.buildTokenService(SecurityUtil.java:378)
        at org.apache.hadoop.hdfs.NameNodeProxies.createNonHAProxy(NameNodeProxies.java:310)
        at org.apache.hadoop.hdfs.NameNodeProxies.createProxy(NameNodeProxies.java:176)
        at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:678)
        at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:619)
        at org.apache.hadoop.hdfs.DistributedFileSystem.initialize(DistributedFileSystem.java:149)
        at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2653)
        at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:92)
        at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2687)
        at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2669)
        at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:371)
        at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:170)
        at org.apache.drill.exec.store.dfs.DrillFileSystem.<init>(DrillFileSystem.java:91)
        at org.apache.drill.exec.store.dfs.DrillFileSystem.<init>(DrillFileSystem.java:87)
        at org.apache.drill.exec.store.sys.store.LocalPersistentStore.getFileSystem(LocalPersistentStore.java:110)
        at org.apache.drill.exec.store.sys.store.provider.LocalPersistentStoreProvider.<init>(LocalPersistentStoreProvider.java:53)
        at org.apache.drill.exec.server.Drillbit.<init>(Drillbit.java:145)
        at org.apache.drill.exec.server.Drillbit.<init>(Drillbit.java:108)
        at org.apache.drill.jdbc.impl.DrillConnectionImpl.<init>(DrillConnectionImpl.java:132)
        ... 18 more
Caused by: java.net.UnknownHostException: adamstasiak-test-13013-drill-ha
        ... 37 more
apache drill 1.12.0 
"start your sql engine"
0: jdbc:drill:zk=local> SELECT * FROM cp.`employee.json` LIMIT 3;
No current connection
0: jdbc:drill:zk=local> Error: Failure in starting embedded Drillbit: java.lang.IllegalArgumentException: java.net.UnknownHostException: adamstasiak-test-13013-drill-ha (state=,code=0)

 ```

@karth295  What do you think about those changes and issues? 
