### PR TITLE
Increasing the number of open files in Presto.

### DIFF
--- a/presto/presto.sh
+++ b/presto/presto.sh
@@ -96,6 +96,9 @@ cat > presto-server-${PRESTO_VERSION}/etc/jvm.config <<EOF
 -Djava.library.path=/usr/lib/hadoop/lib/native/:/usr/lib/
 EOF
 
+# Increase the number of open files allowed.
+ulimit -n 65000
+
 # Start coordinator only on main Master
 if [[ "${HOSTNAME}" == "${PRESTO_MASTER_FQDN}" ]]; then
   # Configure master properties


### PR DESCRIPTION
The default limit of open files in Presto appears to be 4096. However, in newer versions of Presto, this limit is too low, resulting in "java.io.IOException: Too many open files." This prevents new connections from being opened and manifests itself to the user as a failure to list a file.

This change raises the default limit so that this doesn't happen.