### PR TITLE
Revert "Install matplotlib for Jupyter"

### DIFF
--- a/jupyter/jupyter.sh
+++ b/jupyter/jupyter.sh
@@ -45,7 +45,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
   conda install jupyter
 
   # For storing notebooks on GCS. Pin version to make this script hermetic.
-  pip install --upgrade jgscm==0.1.7 matplotlib
+  pip install jgscm==0.1.7
 
   ./dataproc-initialization-actions/jupyter/internal/setup-jupyter-kernel.sh
   ./dataproc-initialization-actions/jupyter/internal/launch-jupyter-kernel.sh


### PR DESCRIPTION
Reverts GoogleCloudPlatform/dataproc-initialization-actions#237

Reverting this PR because it does not work on Dataproc 1.0/1.1. E.g.

```
Successfully built jgscm gcloud tornado httplib2 googleapis-common-protos backcall
Installing collected packages: httplib2, setuptools, six, protobuf, googleapis-common-protos, pyasn1, pyasn1-modules, rsa, oauth2client, gcloud, tornado, jupyter-core, python-dateutil, pyzmq, jupyter-client, parso, jedi, decorator, backcall, pexpect, ipython, ipykernel, terminado, jinja2, testpath, webencodings, html5lib, bleach, mistune, nbconvert, Send2Trash, notebook, jgscm, cycler, pytz, numpy, kiwisolver, matplotlib
  Found existing installation: setuptools 27.2.0
Cannot remove entries from nonexistent file /opt/conda/lib/python3.5/site-packages/easy-install.pth
You are using pip version 8.1.2, however version 10.0.0 is available.
You should consider upgrading via the 'pip install --upgrade pip' command
```