### PR TITLE
Add an initialization action to install OpenSSL 1.0.2 from backports.

### DIFF
--- a/openssl/README.md
+++ b/openssl/README.md
@@ -5,15 +5,13 @@ from Jessie-backports for Dataproc clusters running Dataproc 1.0 through 1.2.
 
 ## Using this initialization action
 You can use this initialization action to create a new Dataproc cluster with the backports version
-of OpenSSL using the following instructions:
+of OpenSSL using the following command:
 
-1. Uploading a copy of this initialization action (`openssl.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-2. Using the `gcloud` command to create a new cluster with this initialization action.  The following command will create a new cluster named `<CLUSTER_NAME>` and specify the initialization action stored in `<GCS_BUCKET>`
+```bash
+gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://dataproc-initialization-actions/openssl/openssl.sh
+```
 
-    ```bash
-    gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://<GCS_BUCKET>/openssl.sh
-    ```
 ## Important Notes
 
 * This init action should not be applied to Dataproc image versions greater than

--- a/openssl/README.md
+++ b/openssl/README.md
@@ -1,0 +1,20 @@
+# OpenSSL Upgrade
+
+This [initialization action] (https://cloud.google.com/dataproc/init-actions) installs OpenSSL 1.0.2
+from Jessie-backports for Dataproc clusters running Dataproc 1.0 through 1.2.
+
+## Using this initialization action
+You can use this initialization action to create a new Dataproc cluster with the backports version
+of OpenSSL using the following instructions:
+
+1. Uploading a copy of this initialization action (`openssl.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+2. Using the `gcloud` command to create a new cluster with this initialization action.  The following command will create a new cluster named `<CLUSTER_NAME>` and specify the initialization action stored in `<GCS_BUCKET>`
+
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://<GCS_BUCKET>/openssl.sh
+    ```
+## Important Notes
+
+* This init action should not be applied to Dataproc image versions greater than
+  1.2.

--- a/openssl/README.md
+++ b/openssl/README.md
@@ -1,6 +1,6 @@
 # OpenSSL Upgrade
 
-This [initialization action] (https://cloud.google.com/dataproc/init-actions) installs OpenSSL 1.0.2
+This [initialization action](https://cloud.google.com/dataproc/init-actions) installs OpenSSL 1.0.2
 from Jessie-backports for Dataproc clusters running Dataproc 1.0 through 1.2.
 
 ## Using this initialization action
@@ -12,7 +12,7 @@ gcloud dataproc clusters create <CLUSTER_NAME> \
     --initialization-actions gs://dataproc-initialization-actions/openssl/openssl.sh
 ```
 
-## Important Notes
+## Important notes
 
 * This init action should not be applied to Dataproc image versions greater than
   1.2.

--- a/openssl/openssl.sh
+++ b/openssl/openssl.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+function update_apt_get() {
+  for ((i = 0; i < 10; i++)); do
+    if apt-get update; then
+      return 0
+    fi
+    sleep 5
+  done
+  return 1
+}
+
+update_apt_get
+apt-get install -t jessie-backports -y openssl


### PR DESCRIPTION
NPN has been deprecated for quite some time with ALPN being its
replacement. OpenSSL 1.0.1, which is included in Debian 8, does not
support ALPN, only NPN. OpenSSL 1.0.2 supports ALPN.

This initialization action installs OpenSSL 1.0.2 from jessie backports.
Using this initialization action can be useful if using gRPC with
netty-tcnative-dynamic libraries and encountering NPN / ALPN negotation
failures when communicating with Google services from Dataproc clusters.