### PR TITLE
Improve consistency of init action READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,43 +3,69 @@
 When creating a [Google Cloud Dataproc](https://cloud.google.com/dataproc/) cluster, you can specify [initialization actions](https://cloud.google.com/dataproc/init-actions) in executables and/or scripts that Cloud Dataproc will run on all nodes in your Cloud Dataproc cluster immediately after the cluster is set up. Initialization actions often set up job dependencies, such as installing Python packages, so that jobs can be submitted to the cluster without having to install dependencies when the jobs are run.
 
 ## How initialization actions are used
+
 Initialization actions are stored in a [Google Cloud Storage](https://cloud.google.com/storage) bucket and can be passed as a parameter to the `gcloud` command or the `clusters.create` API when creating a Cloud Dataproc cluster. For example, to specify an initialization action when creating a cluster with the `gcloud` command, you can run:
 
-    gcloud dataproc clusters create CLUSTER-NAME
-    [--initialization-actions [GCS_URI,...]]
-    [--initialization-action-timeout TIMEOUT]
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+      [--initialization-actions [GCS_URI,...]] \
+      [--initialization-action-timeout TIMEOUT]
 
-For convenience, copies of initialization actions in this repository are stored in the following Cloud Storage bucket, which is publicly accessible:
+For convenience, copies of initialization actions in this repository are stored in the publicly accessible Cloud Storage bucket `gs://dataproc-initialization-actions`. The folder structure of this Cloud Storage bucket mirrors this repository. You should be able to use this Cloud Storage bucket (and the initialization scripts within it) for your clusters.
 
-    gs://dataproc-initialization-actions
+For example:
 
-The folder structure of this Cloud Storage bucket mirrors this repository. You should be able to use this Cloud Storage bucket (and the initialization scripts within it) for your clusters.
+```bash
+gcloud dataproc clusters create my-presto-cluster \
+  --initialization-actions gs://dataproc-initialization-actions/presto/presto.sh
+```
+
+You are strongly encouraged to copy initialization actions to your own GCS bucket in automated pipelines to ensure hermetic deployments. For example:
+
+```bash
+MY_BUCKET=<gcs-bucket>
+gsutil cp presto/presto.sh gs://$MY_BUCKET/
+gcloud dataproc clusters create my-presto-cluster \
+  --initialization-actions gs://$MY_BUCKET/presto.sh
+```
+
+This is also useful if you want to modify initialization actions to fit your needs.
 
 ## Why these samples are provided
+
 These samples are provided to show how various packages and components can be installed on Cloud Dataproc clusters. You should understand how these samples work before running them on your clusters. The initialization actions provided in this repository are provided **without support** and you **use them at your own risk**.
 
 ## Actions provided
+
 This repository presently offers the following actions for use with Cloud Dataproc clusters.
 
-* Install packages/software on the cluster:
-  * [Anaconda](https://www.continuum.io/why-anaconda)
+* Install additional Apache Hadoop ecosystem components
   * [Apache Drill](http://drill.apache.org)
   * [Apache Flink](http://flink.apache.org)
+  * [Apache Gobblin](https://gobblin.apache.org/)
+  * [Apache Hive HCatalog](https://cwiki.apache.org/confluence/display/Hive/HCatalog)
   * [Apache Kafka](http://kafka.apache.org)
+  * [Apache Livy](https://livy.incubator.apache.org/)
   * [Apache Oozie](http://oozie.apache.org)
   * [Apache Tez](http://tez.apache.org)
-  * [Apache Zeppelin](http://zeppelin.apache.org)
   * [Apache ZooKeeper](http://zookeeper.apache.org)
-  * [Google Cloud Datalab](https://cloud.google.com/datalab/)
-  * [Hive HCatalog](https://cwiki.apache.org/confluence/display/Hive/HCatalog)
-  * [Hue](http://gethue.com)
-  * [Intel BigDL](https://bigdl-project.github.io)
-  * [Jupyter](http://jupyter.org/)
   * [Presto](http://prestodb.io)
-* Configure the cluster:
+* Improve data science and interactive experiences
+  * [Miniconda](https://conda.io/docs/)
+  * [Jupyter](http://jupyter.org/)
+  * [Apache Zeppelin](http://zeppelin.apache.org)
+  * [Google Cloud Datalab](https://cloud.google.com/datalab/)
+  * [RStudio Server](https://www.rstudio.com/products/rstudio/#Server)
+  * [Intel BigDL](https://bigdl-project.github.io)
+  * [Hue](http://gethue.com)
+* Configure the environment
   * Configure a *nice* shell environment
-  * Share a [Google Cloud SQL](https://cloud.google.com/sql/) Hive Metastore
-  * Setup [Google Stackdriver](https://cloud.google.com/stackdriver/) monitoring for a cluster
+  * To switch to Python 3, use the conda initialization action
+* Connect to Google Cloud Platform services
+  * Install alternate versions of the [Cloud Storage and BigQuery connectors](https://github.com/GoogleCloudPlatform/bigdata-interop/releases). [Specific versions](https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions) of these connectors come pre-installed on Cloud Dataproc clusters.
+  * Share a [Google Cloud SQL](https://cloud.google.com/sql/) Hive Metastore, or simply read/write data from Cloud SQL.
+* Set up monitoring
+  * [Google Stackdriver](https://cloud.google.com/stackdriver/)
+  * [Ganglia](http://ganglia.info/)
 
 ## Initialization actions on single node clusters
 
@@ -55,6 +81,7 @@ Some initialization actions are known **not to work** on Single Node clusters. A
 Feel free to send pull requests or file issues if you have a good use case for running one of these actions on a Single Node cluster.
 
 ## For more information
+
 For more information, review the [Cloud Dataproc documentation](https://cloud.google.com/dataproc/init-actions). You can also pose questions to the [Stack Overflow](http://www.stackoverflow.com) community with the tag `google-cloud-dataproc`.
 See our other [Google Cloud Platform github
 repos](https://github.com/GoogleCloudPlatform) for sample applications and

--- a/bigdl/README.md
+++ b/bigdl/README.md
@@ -6,6 +6,7 @@ BigDL is a distributed deep learning library for Apache Spark. More information 
 [project's website](https://bigdl-project.github.io/)
 
 ## Using this initialization action
+
 You can use this initialization to create a new Dataproc cluster with BigDL's Spark and PySpark libraries installed.
 
 ```
@@ -28,7 +29,7 @@ gcloud dataproc clusters create <CLUSTER_NAME> \
 
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 
-## Important Notes
+## Important notes
 
 * You cannot use preemptible VMs with this init action, nor scale (add or remove workers from) the cluster. BigDL needs to know the exact number of Spark executors and cores per executor to make optimizations for Intel's MKL library (which BigDL ships with). This init action statically sets `spark.executor.instances` based on the original size of the cluster, and **disables** dynamic allocation (`spark.dynamicAllocation.enabled=false`).
 * The init action sets `spark.executor.instances` such that a single application takes up all the resources in a cluster. To run multiple applications simulatenously, override `spark.executor.instances` on each job using `--properties` to `gcloud dataproc jobs submit [spark|pyspark|spark-sql]` or `--conf` to `spark-shell`/`spark-submit`. Note that each application needs to schedule an app master in addition to the executors.

--- a/cloud-sql-proxy/README.MD
+++ b/cloud-sql-proxy/README.MD
@@ -3,6 +3,7 @@
 This initialization action installs a [Google Cloud SQL proxy](https://cloud.google.com/sql/docs/sql-proxy) on every node in a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. It also configures the cluster to store [Apache Hive](https://hive.apache.org) metadata on a given Cloud SQL instance.
 
 ## Using this initialization action
+
 You can use this initialization action to create a Dataproc cluster using a shared hive metastore.:
 
 1. Using the `gcloud` command to create a new 2nd generation Cloud SQL intance (or use a previously created instance). You must enable the [Cloud SQL API](https://console.cloud.google.com/apis/library/sqladmin.googleapis.com/?q=sql) for your project.
@@ -14,14 +15,12 @@ You can use this initialization action to create a Dataproc cluster using a shar
     ```
     a. Optionally create (or already have) other 2nd generation instances, which you wish to be accessible.
 
-2. Uploading a copy of this initialization action (`cloud-sql-proxy.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-
-3. Using the `gcloud` command to create a new cluster with this initialization action.
+1. Using the `gcloud` command to create a new cluster with this initialization action.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
     --scopes sql-admin \
-    --initialization-actions gs://<GCS_BUCKET>/cloud-sql-proxy.sh \
+    --initialization-actions gs://dataproc-initialization-actions/cloud-sql-proxy/cloud-sql-proxy.sh \
     --properties hive:hive.metastore.warehouse.dir=gs://<GCS_BUCKET>/hive-warehouse \
     --metadata "hive-metastore-instance=<PROJECT_ID>:<REGION>:<INSTANCE_NAME>"
     ```
@@ -31,21 +30,21 @@ You can use this initialization action to create a Dataproc cluster using a shar
     --metadata "additional-cloud-sql-instances=<PROJECT_ID>:<REGION>:<ANOTHER_INSTANCE_NAME>=tcp<PORT_#>[,...]"
     ```
 
-4. Submit pyspark_metastore_test.py to the cluster to validate the metatstore and SQL proxies.
+1. Submit pyspark_metastore_test.py to the cluster to validate the metatstore and SQL proxies.
     ```bash
     gcloud dataproc jobs submit pyspark --cluster <CLUSTER_NAME> pyspark_metastore_test.py
     ```
     a. You can test connections to your other instance(s) using the url `"jdbc:mysql//localhost:<PORT_#>?user=root"`
 
-5. Create another dataproc cluster with the same Cloud SQL metastore.
+1. Create another dataproc cluster with the same Cloud SQL metastore.
     ```bash
     gcloud dataproc clusters create <ANOTHER_CLUSTER_NAME> \
     --scopes sql-admin \
-    --initialization-actions gs://<GCS_BUCKET>/cloud-sql-proxy.sh \
+    --initialization-actions gs://dataproc-initialization-actions/cloud-sql-proxy/cloud-sql-proxy.sh \
     --metadata "hive-metastore-instance=<PROJECT_ID>:<REGION>:<INSTANCE_NAME>"
     ```
 
-6. The two clusters should now be sharing Hive Tables and Spark SQL Dataframes saved as tables.
+1. The two clusters should now be sharing Hive Tables and Spark SQL Dataframes saved as tables.
 
 ## Important notes for Hive metastore
 * Hive stores the metadata of all tables in it's metastore. It stores the contents of (non-external) tables in a HCFS directory, which is by default on HDFS. If you want to perist your tables beyond the life of the cluster, set "hive.metastore.warehouse.dir" to a shared locations (such as the Cloud Storage directory in the example above). This directory get's baked into the Cloud SQL metastore, so it is recommended to set even if you intend to mostly use external tables. If you place this direcotry in Cloud Storage. You may want to use the shared NFS consistency cache as well.
@@ -59,7 +58,7 @@ The initialization action can also be configured to install proxies without chan
 ```bash
 gcloud dataproc clusters create <CLUSTER_NAME> \
     --scopes sql-admin \
-    --initialization-actions gs://<GCS_BUCKET>/cloud-sql-proxy.sh \
+    --initialization-actions gs://dataproc-initialization-actions/cloud-sql-proxy/cloud-sql-proxy.sh \
     --metadata "enable-cloud-sql-hive-metastore=false"
     --metadata "additional-cloud-sql-instances=<PROJECT_ID>:<REGION>:<ANOTHER_INSTANCE_NAME>
 ```

--- a/conda/README.MD
+++ b/conda/README.MD
@@ -3,11 +3,13 @@
 ## Overview
 
 This folder contains initialization actions for use Miniconda / conda, who can be introduced as:
- 
+
 - [Minconda](http://conda.pydata.org/miniconda.html), a barebones version of [Anaconda](https://www.continuum.io/why-anaconda) of an open source (and totally legit) Python distro from Continuum Analytics, alongside,
 - [conda](http://conda.pydata.org/docs/), an open source (and amazing) package and environment management system.
 
 This allows Dataproc users to quickly and easily provision a Dataproc cluster leveraging conda's powerful management capabilities, by specifying a list of conda and / or pip packages along with use of [conda environment definitions](https://github.com/conda/conda-env#environment-file-example). All configuration is exposed via environment variables set to sane point-and-shoot defaults.
+
+## Using this initialization action
 
 ### Just install and configure conda environment
 
@@ -68,15 +70,14 @@ gsutil -m cp -r gs://dataproc-initialization-actions/conda/install-conda-env.sh 
 
 chmod 755 ./*conda*.sh
 
-# Install Miniconda / conda                                                                                   
+# Install Miniconda / conda
 ./bootstrap-conda.sh
-# Create / Update conda environment via conda yaml                                                            
+# Create / Update conda environment via conda yaml
 CONDA_ENV_YAML=$CONDA_ENV_YAML_PATH ./install-conda-env.sh
 
 ```
 
-
-## Details 
+## Internal details
 
 ### bootstrap-conda.sh
 
@@ -91,7 +92,7 @@ In addition, the script:
 - installs some useful extensions:
     - [`conda-build`](https://github.com/conda/conda-build)
     - [`anaconda-client`](https://github.com/Anaconda-Server/anaconda-client)
-    
+
 See the script source for more options on configuration. :)
 
 ### install-conda-env.sh

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -6,13 +6,15 @@ and [BigQuery connector](https://github.com/GoogleCloudPlatform/bigdata-interop/
 on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster.
 
 ## Using this initialization action
+
 You can use this initialization action to create a new Dataproc cluster with specific version of
 Google Cloud Storage and BigQuery connector installed:
+
 ```
 gcloud dataproc clusters create <CLUSTER_NAME> \
     --initialization-actions gs://dataproc-initialization-actions/connectors/connectors.sh \
     --metadata 'gcs-connector-version=1.7.0' \
-    --metadata 'bigquery-connector-version=0.11.0'   
+    --metadata 'bigquery-connector-version=0.11.0'
 ```
 
 This script downloads specified version of Google Cloud Storage and BigQuery connector and deletes
@@ -43,6 +45,3 @@ For example:
       --initialization-actions gs://dataproc-initialization-actions/connectors/connectors.sh \
       --metadata 'gcs-connector-version=1.8.0'
   ```
-
-You can find more information about using initialization actions with Dataproc in the
-[Dataproc documentation](https://cloud.google.com/dataproc/init-actions).

--- a/datalab/README.md
+++ b/datalab/README.md
@@ -2,22 +2,23 @@
 
 This initialization action downloads and runs a [Google Cloud Datalab](https://cloud.google.com/datalab/) Docker container on a Dataproc cluster. You will need to connect to Datalab using an SSH tunnel.
 
-Once you have configured a copy of this script, you can use this initialization action to create a new Dataproc cluster with the Datalab server installed by:
+## Using this initialization action
 
-1. Uploading a copy of the initialization action (`datalab.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-1. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>` and specify the initialization action stored in `<GCS_BUCKET>`.
+1. Use the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
-        --initialization-actions gs://<GCS_BUCKET>/datalab/datalab.sh \
+        --initialization-actions gs://dataproc-initialization-actions/datalab/datalab.sh \
         --scopes cloud-platform
     ```
+
 1. Once the cluster has been created, Datalab is configured to run on port `8080` on the master node in a Dataproc cluster. To connect to the Datalab web interface, you will need to create an SSH tunnel and use a SOCKS 5 Proxy as described in the [dataproc web interfaces](https://cloud.google.com/dataproc/cluster-web-interfaces) documentation.
+
 1. Once you bring up a notebook, you should have the normal PySpark environment configured with `sc`, `sqlContext`, and `spark` predefined.
 
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 
-## Notes
+## Important notes
 
 * PySpark's [`DataFrame.toPandas()`](http://spark.apache.org/docs/latest/api/python/pyspark.sql.html#pyspark.sql.DataFrame.toPandas) method is useful for integrating with Datalab APIs.
   * Remember that Panda's DataFrames must fit on the master, whereas Spark's can fill a cluster.

--- a/drill/README.md
+++ b/drill/README.md
@@ -6,16 +6,12 @@ This initialization action installs [Apache Drill](http://drill.apache.org) on a
 
 Check the variables set in the script to ensure they're to your liking.
 
-Once you have configured a copy of this script, you can use this initialization action to create a new Dataproc cluster with Drill installed by:
-
-1. Uploading a copy of the [initialization action for zookeeper](https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/tree/master/zookeeper) to [Google Cloud Storage](https://cloud.google.com/storage).
-1. Uploading a copy of the initialization action (`drill.sh`) to GCS.
-1. Using the `gcloud` command to create a new cluster with zookeeper and this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
+1. Use the `gcloud` command to create a new cluster with zookeeper and this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://<GCS_BUCKET>/zookeeper.sh,gs://<GCS_BUCKET>/drill.sh
-    --initialization-action-timeout 5m
+    --initialization-actions gs://dataproc-initialization-actions/zookeeper/zookeeper.sh \
+    --initialization-actions gs://dataproc-initialization-actions/drill/drill.sh
     ```
 1. Once the cluster has been created, Drillbits will start on all nodes. You can log into any node of the cluster to run Drill queries. Drill is installed in `/usr/lib/drill` (unless you change the setting) which contains a `bin` directory with `sqlline`.
 

--- a/flink/README.md
+++ b/flink/README.md
@@ -4,17 +4,15 @@ This initialization action installs a binary release of [Apache Flink](http://fl
 Flink and start a Flink session running on YARN.
 
 ## Using this initialization action
-You can use this initialization action to create a new Dataproc cluster with Flink installed by:
 
-1. Uploading a copy of the initialization action (`flink.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-1. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
+1. Use the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://<GCS_BUCKET>/flink.sh   
-    --initialization-action-timeout 5m
+    --initialization-actions gs://dataproc-initialization-actions/flink/flink.sh
     ```
-1. 1. You can log into the master node of the cluster to submit jobs to Flink. Flink is installed in `/usr/lib/flink` (unless you change the setting) which contains a `bin` directory with Flink. **Note** - you need to specify `HADOOP_CONF_DIR=/etc/hadoop/conf` before your Flink commands for them to execute properly. 
+
+1. You can log into the master node of the cluster to submit jobs to Flink. Flink is installed in `/usr/lib/flink` (unless you change the setting) which contains a `bin` directory with Flink. **Note** - you need to specify `HADOOP_CONF_DIR=/etc/hadoop/conf` before your Flink commands for them to execute properly.
 
 To run a job on an existing YARN session, run:
 
@@ -42,5 +40,6 @@ sudo su - HADOOP_CONF_DIR=/etc/hadoop/conf /usr/lib/flink/bin/flink run -m yarn-
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 
 ## Important notes
+
 * By default, a detached Flink YARN session is started for you. To find its application id, run `yarn application -list`.
 * The default session is configured to consume all YARN resources. If you want to submit multiple jobs in parallel or use transient sessions, you'll need to disable this default session. You can either fork this init script and set START_FLINK_YARN_SESSION_DEFAULT to `false`, or set the cluster metadata key `flink-start-yarn-session` to `false` when you create your cluster.

--- a/ganglia/README.MD
+++ b/ganglia/README.MD
@@ -1,6 +1,14 @@
 # Ganglia
 
-This initialization action installs [Ganglia](http://ganglia.info/).
+This initialization action installs [Ganglia](http://ganglia.info/), a scalable monitoring system.
 
-Ganglia is configured to run on port `80` on the master node in a Dataproc cluster.
-Access it at: http://masterip/ganglia
+## Using this initialization action
+
+1. Use the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`.
+
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://dataproc-initialization-actions/ganglia/ganglia.sh
+    ```
+
+1. Once the cluster has been created, Ganglia is served on port `80` on the master node at `/ganglia`. To connect to the Ganglia web interface, you will need to create an SSH tunnel and use a SOCKS 5 Proxy with your web browser as described in the [dataproc web interfaces](https://cloud.google.com/dataproc/cluster-web-interfaces) documentation. In the opened web browser, go to `http://CLUSTER_NAME-m/ganglia` on Standard/Single Node clusters, or `http://CLUSTER_NAME-m-0/ganglia` on High Availability clusters.

--- a/gobblin/README.md
+++ b/gobblin/README.md
@@ -7,16 +7,17 @@ This [initialization action](https://cloud.google.com/dataproc/init-actions) ins
 The distribution is hosted in Dataproc-team owned Google Cloud Storage bucket `gobblin-dist`.
 
 ## Using this initialization action
+
 You can use this initialization action to create a new Dataproc cluster with Gobblin installed by:
 
-1. Using the `gcloud` command to create a new cluster with this initialization action.
+1. Use the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
         --initialization-actions gs://dataproc-initialization-actions/gobblin/gobblin.sh
     ```
 
-2. Submit jobs
+1. Submit jobs
 
     ```bash
     gcloud dataproc jobs submit hadoop --cluster=<CLUSTER_NAME> \
@@ -29,10 +30,10 @@ You can use this initialization action to create a new Dataproc cluster with Gob
    Alternatively, you can submit jobs through Gobblin launcher scripts located in
    `/usr/local/lib/gobblin/bin`. By default, Gobblin is only configured for mapreduce mode.
 
-3. To learn about how to use Gobblin read the documentation for the
+1. To learn about how to use Gobblin read the documentation for the
    [Getting Started](https://gobblin.readthedocs.io/en/latest/) guide.
 
-## Important Notes
+## Important notes
 
 1. For Gobblin to work with Dataproc Job API, any additional client libraries
    (for example: Kafka, MySql) would have to be symlinked into `/usr/lib/hadoop/lib` directory on

--- a/hive-hcatalog/README.md
+++ b/hive-hcatalog/README.md
@@ -6,13 +6,12 @@ This initialization action installs [Hive HCatalog](https://cwiki.apache.org/con
 
 You can use this initialization action to create a new Cloud Dataproc cluster with HCatalog installed by doing the following.
 
-1. Uploading a copy of this initialization action (`hive-hcatalog.sh`) to [Google Cloud Storage](https://cloud.google.com/storage). Alternatively, you can use the Google-hosted copy of this initialization action at `gs://dataproc-initialization-actions/hive-hcatalog/hive-hcatalog.sh`
-2. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER-NAME>`, specify the initialization action stored in `<GCS-BUCKET>`:
+1. Use the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER-NAME> \
-    --initialization-actions gs://<GCS-BUCKET>/hive-hcatalog.sh
+      --initialization-actions gs://dataproc-initialization-actions/hive-hcatalog/hive-hcatalog.sh
     ```
-3. Once the cluster has been created HCatalog should be installed and configured for use with Pig.
 
-You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+1. Once the cluster has been created HCatalog should be installed and configured for use with Pig.
+

--- a/hue/README.md
+++ b/hue/README.md
@@ -4,20 +4,18 @@ This [initialization action] (https://cloud.google.com/dataproc/init-actions) in
 on a master node within a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster.
 
 ## Using this initialization action
-You can use this initialization action to create a new Dataproc cluster with Hue installed by:
 
-1. Uploading a copy of this initialization action (`hue.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-2. Using the `gcloud` command to create a new cluster with this initialization action.  The following command will create a new cluster named `<CLUSTER_NAME>` and specify the initialization action stored in `<GCS_BUCKET>`
+You can use this initialization action to create a new Dataproc cluster with Hue installed:
+
+1. Use the `gcloud` command to create a new cluster with this initialization action.  The following command will create a new cluster named `<CLUSTER_NAME>`.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://<GCS_BUCKET>/hue.sh
+      --initialization-actions gs://dataproc-initialization-actions/hue/hue.sh
     ```
-Alternatively, you can start a regular dataproc cluster, [ssh to the master node]  (https://cloud.google.com/dataproc/submit-job) (see SSH into instance), clone this repository and run ./hue.sh (as sudo)
 
-3. Once the cluster has been created, Hue is configured to run on port `8888` on the master node in a Dataproc cluster. To connect to the Hue web interface, you will need to create an SSH tunnel and use a SOCKS 5 Proxy with your web browser as described in the [dataproc web interfaces](https://cloud.google.com/dataproc/cluster-web-interfaces) documentation.
-In the opened web browser go to 'localhost:8888' and you should see the Hue UI.
+1. Once the cluster has been created, Hue is configured to run on port `8888` on the master node in a Dataproc cluster. To connect to the Hue web interface, you will need to create an SSH tunnel and use a SOCKS 5 Proxy with your web browser as described in the [dataproc web interfaces](https://cloud.google.com/dataproc/cluster-web-interfaces) documentation. In the opened web browser go to 'localhost:8888' and you should see the Hue UI.
 
-## Important Notes
+## Important notes
 
 * If you wish to use Oozie in HUE, it must be installed before running this initialization action e.g. put the [Oozie initialization action](../oozie/README.md) before this one in the list to cloud.

--- a/jupyter/README.MD
+++ b/jupyter/README.MD
@@ -4,7 +4,11 @@ This folder contains the initialization action `jupyter.sh` to quickly setup and
 
 Note: This init action uses Conda and Python 3. Python 2 and `pip` uesrs should consider using the [jupyter2 action](https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/tree/master/jupyter2).
 
-A real-world example of how to use this from within a bash script, using the default dataproc-initialization-actions repo/branch:
+## Using this initialization action
+
+You can use this initialization action to create a new Dataproc cluster with Jupyter installed:
+
+1. Use the `gcloud` command to create a new cluster with this initialization action.  The following command will create a new cluster named `<CLUSTER_NAME>`.
 
 ```bash
 # Simple one-liner; just use all default settings for your cluster. Jupyter will run on port 8123
@@ -14,36 +18,34 @@ gcloud dataproc clusters create my-dataproc-cluster \
         gs://dataproc-initialization-actions/jupyter/jupyter.sh \
 ```
 
-There are various options for customizing your Jupyter installation. For example to change the port
-on which the Jupyter server runs, you can set the metadata key `JUPYTER_PORT`. You may also want
-to change the number of workers and machine type of your cluster:
+1. Run `./launch-jupyter-interface` to connect to the Jupyter notebook running on the master node. This creates a SOCKS5 proxy to the master node and launches a Google Chrome window that uses this proxy. Note: you will need to edit the script to point it at the Chrome installation path for your operating system. Alternatively, follow the instructions in [connecting to cluster web interfaces](https://cloud.google.com/dataproc/docs/concepts/cluster-web-interfaces).
 
-```bash
-# Override the Jupyter port with 8124 (default is 8123)
-gcloud dataproc clusters create my-dataproc-cluster \
-    --metadata "JUPYTER_PORT=8124" \
-    --initialization-actions \
-        gs://dataproc-initialization-actions/jupyter/jupyter.sh \
-    --num-workers 2 \
-    --properties spark:spark.executorEnv.PYTHONHASHSEED=0,spark:spark.yarn.am.memory=1024m \
-    --worker-machine-type=n1-standard-4 \
-    --master-machine-type=n1-standard-4
-```
-You can pre-install various Python packages through `conda` by specifying a colon-separated
-list in the metadata entry `JUPYTER_CONDA_PACKAGES`:
+### Options
+
+There are various options for customizing your Jupyter installation. These can be provided as metadata keys using `--metadata`.
+
+* `JUPYTER_PORT`=<integer>: Port on which the Jupyter server runs
+* `JUPYTER_CONDA_PACKAGES`=<colon-separated list of strings>: List of Conda packages to install.
+* `INIT_ACTIONS_REPO`=<https url>: Repo to clone to find other scripts to install/configure Conda and Jupyter.
+* `INIT_ACTIONS_BRANCH`=<string>: Branch in `INIT_ACTIONS_REPO` to use.
+
+For example to specify a different port and specify additional packages to install:
 
 ```bash
 gcloud dataproc clusters create my-dataproc-cluster \
     --metadata "JUPYTER_PORT=8124,JUPYTER_CONDA_PACKAGES=numpy:pandas:scikit-learn" \
     --initialization-actions \
         gs://dataproc-initialization-actions/jupyter/jupyter.sh \
-    --num-workers 2 \
     --properties spark:spark.executorEnv.PYTHONHASHSEED=0,spark:spark.yarn.am.memory=1024m \
     --worker-machine-type=n1-standard-4 \
     --master-machine-type=n1-standard-4
 ```
 
-## jupyter.sh
+Notebooks are stored and retrieved from the cluster staging bucket (Google Cloud Storage) at `gs://<staging-bucket>/notebooks/`. By default, clusters in your project in the same region use the same bucket. You can explicitly provide `--bucket=gs://<some-bucket>` to the same value to share notebooks between them.
+
+## Internal details
+
+### jupyter.sh
 
 `jupyter.sh` handles configuring and running Jupyter on the Dataproc master node by doing the following:
 
@@ -63,7 +65,7 @@ gcloud dataproc clusters create my-dataproc-cluster \
 **NOTE**: to be run as an init action.
 
 
-## launch-jupyter-interface.sh
+### launch-jupyter-interface.sh
 
 `launch-jupyter-interface.sh` launches a web interface to connect to Jupyter notebook process running on master node.
 
@@ -72,4 +74,9 @@ gcloud dataproc clusters create my-dataproc-cluster \
 - launch a Chrome instance that uses this ssh tunnel and references the Jupyter port.
 
 **NOTE**: to be run from a local machine
+
+## Important notes
+
+* This initialization action clones this repo at `master` to run other scripts in the repo. If you plan to copy `jupyter.sh` to your own GCS bucket, you will also need to fork this repository and specify the metadata keys `INIT_ACTIONS_REPO` and `INIT_ACTIONS_BRANCH`.
+* This initialization action runs the conda init action, which supports the metadata keys `CONDA_PACKAGES` and `PIP_PACKAGES`. You can also use these to install additional packages.
 

--- a/jupyter/README.MD
+++ b/jupyter/README.MD
@@ -10,13 +10,13 @@ You can use this initialization action to create a new Dataproc cluster with Jup
 
 1. Use the `gcloud` command to create a new cluster with this initialization action.  The following command will create a new cluster named `<CLUSTER_NAME>`.
 
-```bash
-# Simple one-liner; just use all default settings for your cluster. Jupyter will run on port 8123
-# of your master node.
-gcloud dataproc clusters create my-dataproc-cluster \
-    --initialization-actions \
-        gs://dataproc-initialization-actions/jupyter/jupyter.sh \
-```
+    ```bash
+    # Simple one-liner; just use all default settings for your cluster. Jupyter will run on port 8123
+    # of your master node.
+    gcloud dataproc clusters create my-dataproc-cluster \
+        --initialization-actions \
+            gs://dataproc-initialization-actions/jupyter/jupyter.sh \
+    ```
 
 1. Run `./launch-jupyter-interface` to connect to the Jupyter notebook running on the master node. This creates a SOCKS5 proxy to the master node and launches a Google Chrome window that uses this proxy. Note: you will need to edit the script to point it at the Chrome installation path for your operating system. Alternatively, follow the instructions in [connecting to cluster web interfaces](https://cloud.google.com/dataproc/docs/concepts/cluster-web-interfaces).
 

--- a/jupyter2/README.md
+++ b/jupyter2/README.md
@@ -2,7 +2,7 @@
 
 This initialization action installs the latest version of [Jupyter Notebook](http://jupyter.org/) with `pip` and Python 2. Conda and Python 3 users should instead use the original [Jupyter init action](https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/tree/master/jupyter).
 
-## Usage
+## Using this initialization action
 
 Usage is similar to the original `jupyter` init action.
 
@@ -11,7 +11,9 @@ gcloud dataproc clusters create <cluster-name> \
   --initialization-actions gs://dataproc-initialization-actions/jupyter2/jupyter2.sh
 ```
 
-The same options are supported here:
+### Options
+
+A few of same options are supported here:
 
 * `--bucket=gs://<some-bucket>` (the cluster staging bucket) is used for storing and retrieving notebooks. Set this to the same value when recreating clusters to share notebooks between them. By default, clusters in your project in the same region use the same bucket.
 * `--metadata JUPYTER_PORT=<some-port>` can be used to override the default port (8123)
@@ -25,3 +27,4 @@ gcloud dataproc clusters create <cluster-name> \
   --bucket gs://mybucket \
   --metadata JUPYTER_PORT=80,JUPYTER_AUTH_TOKEN=mytoken
 ```
+

--- a/kafka/README.MD
+++ b/kafka/README.MD
@@ -1,17 +1,16 @@
-# Kafka 
+# Kafka
 
 This initialization action installs [Kafka](http://kafka.apache.org) on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. Kafka depends on Zookeeper, which can either be installed with a separate zookeeper initialization action or by simply creating a "High Availability" cluster using `--num-masters 3`.
 
 ## Using this initialization action
-You can use this initialization action to create a new Dataproc cluster with Kafka installed by:
 
-1. Uploading a copy of this initialization action (`kafka.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-1. Using the `gcloud` command to create a new cluster with this initialization action. **Note** - you may need to increase the `initialization-action-timeout` if this script takes a long time to run. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
-   
+You can use this initialization action to create a new Dataproc cluster with Kafka installed:
+
+1. Use the `gcloud` command to create a new cluster with this initialization action. The following command will create a new high availability cluster named `<CLUSTER_NAME>`.
+
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
         --num-masters 3 \
-        --image-version preview \
         --initialization-actions gs://dataproc-initialization-actions/kafka/kafka.sh
     ```
 1. Once the cluster has been created Kafka should be running on all worker nodes in the cluster, and Kafka libraries should be installed on the master node(s). You can test your Kafka setup by creating a simple topic and publishing to it with Kafka's command-line tools, after SSH'ing into one of your master nodes:
@@ -21,7 +20,7 @@ You can use this initialization action to create a new Dataproc cluster with Kaf
 
     # Create a test topic, just talking to the local master's zookeeper server.
     /usr/lib/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --create \
-        --replication-factor 1 --partitions 1 --topic test 
+        --replication-factor 1 --partitions 1 --topic test
     /usr/lib/kafka/bin/kafka-topics.sh --zookeeper localhost:2181 --list
 
     # Use worker 0 as broker to publish 100 messages over 100 seconds
@@ -41,6 +40,7 @@ You can use this initialization action to create a new Dataproc cluster with Kaf
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 
 ## Important notes
+
 * This script will install Kafka on all **worker nodes** by default (but not the master(s))
 * This script assumes you have zookeeper installed, either through the zookeeper.sh init action or by creating a high-availability cluster with `--num-masters 3`
 * The `delete.topic.enable` property has been set to `true` by default so topics can be deleted

--- a/livy/README.md
+++ b/livy/README.md
@@ -5,21 +5,18 @@ This [initialization action](https://cloud.google.com/dataproc/init-actions) ins
 [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster.
 
 ## Using this initialization action
-You can use this initialization action to create a new Dataproc cluster with Livy installed by:
 
-1. Using the `gcloud` command to create a new cluster with this initialization action.
+You can use this initialization action to create a new Dataproc cluster with Livy installed:
+
+1. Use the `gcloud` command to create a new cluster with this initialization action.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
         --initialization-actions gs://dataproc-initialization-actions/livy/livy.sh
     ```
 
-Alternatively, you can start a regular dataproc cluster,
-[ssh to the master node](https://cloud.google.com/dataproc/submit-job) (see SSH into instance),
-clone this repository and run ./livy.sh (as sudo)
-
-2. Once the cluster has been created, Livy is configured to run on port `8998` on the master node
+1. Once the cluster has been created, Livy is configured to run on port `8998` on the master node
    in a Dataproc cluster.
 
-3. To learn about how to use Livy read the documentation for the
+1. To learn about how to use Livy read the documentation for the
    [Rest API](https://livy.incubator.apache.org/docs/latest/rest-api.html)

--- a/oozie/README.MD
+++ b/oozie/README.MD
@@ -6,37 +6,39 @@ This initialization action installs the [Oozie](http://oozie.apache.org) workflo
 [Workflow Templates](https://cloud.google.com/dataproc/docs/concepts/workflows/overview)
 
 ## Using this initialization action
-You can use this initialization action to create a new Dataproc cluster with Oozie installed by:
 
-1. Uploading a copy of this initialization action (`oozie.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-2. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER-NAME>`, specify the initialization action stored in `<GCS-BUCKET>`:
+You can use this initialization action to create a new Dataproc cluster with Oozie installed:
+
+1. Use the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER-NAME>`:
 
     ```bash
     gcloud dataproc clusters create <CLUSTER-NAME> \
-    --initialization-actions gs://<GCS-BUCKET>/oozie.sh
+      --initialization-actions gs://dataproc-initialization-actions/oozie/oozie.sh
     ```
-3. Once the cluster has been created Oozie should be running on the master node.
+1. Once the cluster has been created Oozie should be running on the master node.
 
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 
 ## Testing Oozie
+
 You can test this Oozie installation by running the `oozie-examples` included with Oozie. The examples are in an archive at `/usr/share/doc/oozie/oozie-examples.tar.gz`. To run the MapReduce example, you can do the following:
 
 1. Move the examples to your home directory:<br/>
 `cp /usr/share/doc/oozie/oozie-examples.tar.gz ~`
-2. Decompress the archive:<br/>
+1. Decompress the archive:<br/>
 `tar -zxvf oozie-examples.tar.gz`
-3. Edit the MapReduce example with details for your cluster:<br/>
+1. Edit the MapReduce example with details for your cluster:<br/>
 `nameNode=hdfs://<cluster-name-m>:8020`<br/>
 `jobTracker=<cluster-name-m>:8032`
-4. Move the Oozie examples to HDFS:<br/>
+1. Move the Oozie examples to HDFS:<br/>
 `hadoop fs -put ~/examples/ /user/<username>/`
-5. Run the example on the command line with:<br/>
+1. Run the example on the command line with:<br/>
 `oozie job -oozie http://127.0.0.1:11000/oozie -config \
 ~/examples/apps/map-reduce/job.properties -run`
 
 
 ## Oozie web interface
+
 The Oozie web interface is available on port `11000` on the master node of the cluster. For example, the Oozie web intarface would be available at the following address for a cluster named `my-dataproc-cluster`:
 
     http://my-dataproc-cluster-m:11000/oozie
@@ -44,6 +46,7 @@ The Oozie web interface is available on port `11000` on the master node of the c
 To connect to the web interface you will need to create an SSH tunnel and use a SOCKS proxy. Instructions on how to do this are available in the [cloud dataproc documentation](https://cloud.google.com/dataproc/cluster-web-interfaces).
 
 ## Important notes
+
 * As Oozie is updated in BigTop the version of Oozie which is installed with this action will change.
 * HDFS is running on port `8020` and the (YARN) JobTracker is on port `8032` which may be useful information for some jobs.
 * The [`hive2` action](https://oozie.apache.org/docs/4.3.0/DG_Hive2ActionExtension.html) is recommended over the [`hive` action](https://oozie.apache.org/docs/4.3.0/DG_HiveActionExtension.html).

--- a/presto/README.MD
+++ b/presto/README.MD
@@ -1,17 +1,15 @@
-# Presto 
+# Presto
 
 This initialization action installs the latest version of [Presto](prestodb.io) on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. Additionally, this script will configure Presto to work with Hive on the cluster. The master Cloud Dataproc node will be the coordinator and all Cloud Dataproc workers will be Presto workers.
 
 ## Using this initialization action
-You can use this initialization action to create a new Dataproc cluster with Presto installed by:
+You can use this initialization action to create a new Dataproc cluster with Presto installed:
 
-1. Uploading a copy of this initialization action (`presto.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-1. Using the `gcloud` command to create a new cluster with this initialization action. **Note** - you may need to increase the `initialization-action-timeout` if this script takes a long time to run. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
-   
+1. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`.
+
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://<GCS_BUCKET>/presto.sh   
-    --initialization-action-timeout 5m
+      --initialization-actions gs://dataproc-initialization-actions/presto/presto.sh
     ```
 1. Once the cluster has been created, Presto is configured to run on port `8080` (though you can change this in the script) on the master node in a Cloud Dataproc cluster. To connect to the Presto web interface, you will need to create an SSH tunnel and use a SOCKS 5 Proxy as described in the [dataproc web interfaces](https://cloud.google.com/dataproc/cluster-web-interfaces) documentation. You can also use the [Presto command line interface](https://prestodb.io/docs/current/installation/cli.html) using the `presto` command on the master node.
 

--- a/rstudio/README.MD
+++ b/rstudio/README.MD
@@ -12,6 +12,7 @@ You can use this initialization action to create a new Dataproc cluster with RSt
         --initialization-actions \
             gs://dataproc-initialization-actions/rstudio/rstudio.sh
     ```
+
 1. Once the cluster has been created, RStudio Server is configured to run on port `8787` on the master node in a Dataproc cluster. To connect to the Rtudio Server web interface, you will need to create an SSH tunnel and use a SOCKS 5 Proxy as described in the [dataproc web interfaces](https://cloud.google.com/dataproc/cluster-web-interfaces) documentation.
 
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -13,14 +13,13 @@ with that prefix and use this group as the basis for your alerting policies and 
 group through the [Stackdriver user interface](https://app.google.stackdriver.com/groups/create).
 
 Once you have configured a copy of this script, you can use this initialization action to create a new Dataproc cluster
-with the Stackdriver agent installed by:
+with the Stackdriver agent installed:
 
-1. Uploading a copy of the initialization action (`stackdriver.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-1. Using the `gcloud` command to create a new cluster with this initialization action. You must add the [requisite stackdriver monitoring scope(s)](https://cloud.google.com/monitoring/api/authentication#cloud_monitoring_scopes). The following command will create a new cluster named `<CLUSTER_NAME>` and specify the initialization action stored in `<GCS_BUCKET>`.
+1. Use the `gcloud` command to create a new cluster with this initialization action. You must add the [requisite stackdriver monitoring scope(s)](https://cloud.google.com/monitoring/api/authentication#cloud_monitoring_scopes). The following command will create a new cluster named `<CLUSTER_NAME>`.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
-        --initialization-actions gs://<GCS_BUCKET>/stackdriver.sh \
+        --initialization-actions gs://dataproc-initialization-actions/stackdriver/stackdriver.sh \
         --scopes https://www.googleapis.com/auth/monitoring.write
     ```
 1. Once the cluster is online, Stackdriver should automatically start capturing data from your cluster. You can visit
@@ -34,7 +33,7 @@ To better identify your cluster in a Stackdriver dashboard, you'll likely want t
 your cluster:
 
     gcloud dataproc clusters create <CLUSTER_NAME> \
-        --initialization-actions gs://<GCS_BUCKET>/stackdriver.sh \
+        --initialization-actions gs://dataproc-initialization-actions/stackdriver/stackdriver.sh \
         --scopes https://www.googleapis.com/auth/monitoring.write \
         --tags my-dataproc-cluster-20160901-1518
 
@@ -49,6 +48,7 @@ APIs you can simply copy/paste:
         --tags ${USER}-dataproc-cluster-$(date +%Y%m%d-%H%M%S)
 
 ## Important notes
+
 * If you do not create a group in Stackdriver with the same prefix as your cluster name or using the unique tag you
 provided at cluster-creation time, Stackdriver will not automatically pick up data from your cluster.
 * Ensure you have reviewed the [pricing for Stackdriver](https://cloudplatform.googleblog.com/2016/06/announcing-pricing-for-Google-Stackdriver.html)

--- a/tez/README.MD
+++ b/tez/README.MD
@@ -8,21 +8,22 @@ This initialization action installs the latest version of [Apache Tez](https://t
 4. Hadoop and Hive are configured to work with Tez on the Dataproc cluster
 
 ## Using this initialization action
-You can use this initialization action to create a new Dataproc cluster with Apache Tez installed by:
+You can use this initialization action to create a new Dataproc cluster with Apache Tez installed:
 
-1. Uploading a copy of this initialization action (`tez.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-1. Using the `gcloud` command to create a new cluster with this initialization action. **Note** - you will need to increase the `initialization-action-timeout` to at least 15 minutes to allow for Tez and its dependencies to compile and install. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 15 minutes.
+1. Use the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://<GCS_BUCKET>/tez.sh
+      --initialization-actions gs://dataproc-initialization-actions/tez/tez.sh
     ```
 1. Once the cluster is created, Tez should work with your Cloud Dataproc jobs.
+
 1. Hive should be configured to use Tez, rather than Mapreduce, as its execution engine. This can significantly speed up some Hive queries. Read more in the [Hive on Tez documentation](https://cwiki.apache.org/confluence/display/Hive/Hive+on+Tez).
 
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 
 ## Important notes
+
 * This script has a number of user-defined variables at the top, such as the Tez version and install location.
 * This script builds from source which may cause issues if you use an unstable release.
 * Be careful with the [`protobuf`](https://github.com/google/protobuf) version - Tez often requires a *very specific* version to function properly.

--- a/user-environment/README.MD
+++ b/user-environment/README.MD
@@ -7,9 +7,9 @@ By default it only enables the options already present in the .bashrc that Debia
 ## Using this initialization action
 You can use this initialization action by:
 
-1. Uploading a copy of this initialization action (`user-environment.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+1. Editing and uploading a copy of this initialization action (`user-environment.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
 1. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`:
-   
+
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
     --initialization-actions gs://<GCS_BUCKET>/user-environment

--- a/zeppelin/README.MD
+++ b/zeppelin/README.MD
@@ -3,25 +3,35 @@
 This initialization action installs the latest version of [Apache Zeppelin](https://zeppelin.apache.org/) on a master node within a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster.
 
 ## Using this initialization action
-You can use this initialization action to create a new Dataproc cluster with Apache Zeppelin installed by:
+You can use this initialization action to create a new Dataproc cluster with Apache Zeppelin installed:
 
-1. Uploading a copy of this initialization action (`zeppelin.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-1. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`.
+1. Use the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://<GCS_BUCKET>/zeppelin.sh
+      --initialization-actions gs://dataproc-initialization-actions/zeppelin/zeppelin.sh
     ```
 1. Once the cluster has been created, Zeppelin is configured to run on port `8080` on the master node in a Dataproc cluster. To connect to the Apache Zeppelin web interface, you will need to create an SSH tunnel and use a SOCKS 5 Proxy as described in the [dataproc web interfaces](https://cloud.google.com/dataproc/cluster-web-interfaces) documentation.
 
-You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+### Options
 
-## Important notes & Known issues
-* The port Zeppelin runs on is configurable by passing `--metadata=zeppelin-port=<PORT>' to `gcloud`.
-* This installs Zeppelin 0.5.6 in Dataproc 1.0 and Zeppelin 0.6.1 in Dataproc 1.1.
-* It configures the BigQuery interpreter in 0.6.1.
+This option can be provided as a metadata key using `--metadata`.
+
+* `zeppelin-port`=<integer>: Port on which the Zeppelin server runs
+
+For example:
+
+```bash
+gcloud dataproc clusters create <CLUSTER_NAME> \
+  --initialization-actions gs://dataproc-initialization-actions/zeppelin/zeppelin.sh \
+  --metadata zeppelin-port=8081
+```
+
+## Important notes
+* This installs Zeppelin 0.5.6 in Dataproc 1.0, Zeppelin 0.6.1 in Dataproc 1.1, and Zeppelin 0.7 in Dataproc 1.2.
+* It configures the BigQuery interpreter in 0.6.1+.
 * It installs `matplotlib`. More information about Zeppelin/matplotlib integration [here](https://zeppelin.apache.org/docs/latest/interpreter/python.html#matplotlib-integration).
 * By default it only install Rs graphing libraries that ship with Debian 8 (ggplot2, knitr, and googlevis).
   * To install the other required R libraries (mplot and rCharts), uncomment lines after "Uncomment here" in zeppelin.sh.
   * There are still some issues with examples in the R Tutorial (under investation).
-* The Hive interpreter in missing in Dataproc 1.1 (under investigation).
+* The Hive interpreter in missing in Dataproc 1.1.

--- a/zookeeper/README.MD
+++ b/zookeeper/README.MD
@@ -1,27 +1,25 @@
-# ZooKeeper 
+# ZooKeeper
 
-Presently, [Google Cloud Dataproc](https://cloud.google.com) clusters do not have [ZooKeeper](http://zookeeper.apache.org) insalled. This may change in the future; in the interim, this initialization action installs ZooKeeper on a Cloud Dataproc cluster.
+Though High Availability clusters have ZooKeeper pre-configured, Standard [Google Cloud Dataproc](https://cloud.google.com) clusters do not have [ZooKeeper](http://zookeeper.apache.org) insalled. This may change in the future; in the interim, this initialization action installs ZooKeeper on a Standard Cloud Dataproc cluster.
 
-Specifically, this script will (unless changed) install ZooKeeper on the **three required** nodes for a Cloud Dataproc Cluster:
+This script installs ZooKeeper on the **three required** nodes for a Cloud Dataproc Cluster:
 
 * Master node (`-m`)
 * Worker 1 (`-w-0`)
 * Worker 2 (`-w-1`)
 
 ## Using this initialization action
-You can use this initialization action to create a new Dataproc cluster with ZooKeeper installed by:
+You can use this initialization action to create a new Dataproc cluster with ZooKeeper installed:
 
-1. Uploading a copy of this initialization action (`zookeeper.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
-1. Using the `gcloud` command to create a new cluster with this initialization action. **Note** - you may need to increase the `initialization-action-timeout` if this script takes a long time to run. The following command will create a new cluster named `<CLUSTER_NAME>`, and specify the initialization action stored in `<GCS_BUCKET>`.
-   
+1. Use the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`.
+
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \
-    --initialization-actions gs://<GCS_BUCKET>/zookeeper.sh
+      --initialization-actions gs://dataproc-initialization-actions/zookeeper/zookeeper.sh
     ```
-    Since ZooKeeper installs quickly, it's unlikely you will need to increase the `initialization-action-timeout` unless you have a very large cluster or are running more than one initialization action.
-1. Once the cluster has been created, ZooKeeper is configured to run on port `2181` (though you can change this int he script.)
-
-You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+1. Once the cluster has been created, ZooKeeper is configured to run on port `2181` (though you can change this in the script.)
 
 ## Important notes
 * This script does not optimize ZooKeeper and you may wish to further configure ZooKeeper based on the [official documentation](https://zookeeper.apache.org/doc/trunk/).
+* This script will not work on Single Node clusters, as it requires at least 3 nodes
+* This script should not be run on High Availability clusters, which already have Zookeeper pre-configured.


### PR DESCRIPTION
* Only mention copying init actions to GCS in top-level README.
Component READMEs only mention using
gs://dataproc-initialization-actions

* Add all supported init actions to top level README

* Fix minor stylistic nitpicks
  * Extra newline after any heading
  * Numbered bullets repeatedly use "1. 1." rather than "1. 2. etc"
  * Consistent names for sections like "Important notes" and "Using this
  initialization action"

* Removed mentions of init action timeouts, as the server timeout has
increased to 10 minutes

* Make the Jupyter init action README a little bit easier to digest