### PR TITLE
Restart Dataproc Agent Service after connectors update.

### DIFF
--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -62,9 +62,14 @@ update_connector "gcs" "$GCS_CONNECTOR_VERSION"
 
 # Restarts Dataproc Agent after successful initialization
 restart_dataptoc_agent() {
+  # Dataproc Agent should be restarted after initialization,
+  # that's why we need to wait until Dataproc Agent will create
+  # sentinel file that signals that initialization has finished
   while [[ ! -f /var/lib/google/dataproc/has_run_before ]]; do
     sleep 1
   done
+  # If Dataproc Agent didn't create sentinel file that signals
+  # that initialization failed then restart Dataproc Agent
   if [[ ! -f /var/lib/google/dataproc/has_failed_before ]]; then
     service google-dataproc-agent restart
   fi

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -61,6 +61,9 @@ update_connector "bigquery" "$BIGQUERY_CONNECTOR_VERSION"
 update_connector "gcs" "$GCS_CONNECTOR_VERSION"
 
 # Restarts Dataproc Agent after successful initialization
+# WARNING: this function relies on undocumened and not officially supported Dataproc Agent
+# "sentinel" files to determine successful Agent initialization and not guaranteed
+# to work in the future. Use at your own risk!
 restart_dataptoc_agent() {
   # Because Dataproc Agent should be restarted after initialization, we need to wait until
   # it will create a sentinel file that signals initialization competition (success or failure)
@@ -75,7 +78,7 @@ restart_dataptoc_agent() {
 }
 export -f restart_dataptoc_agent
 
-# Schedule asynchronous Dataproc Agent restart.
+# Schedule asynchronous Dataproc Agent restart so it will use updated connectors.
 # It could not be restarted sycnhronously because Dataproc Agent should be restarted
 # after its initialization, including init actions execution, has been completed.
 bash -c restart_dataptoc_agent & disown

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -61,7 +61,7 @@ update_connector "bigquery" "$BIGQUERY_CONNECTOR_VERSION"
 update_connector "gcs" "$GCS_CONNECTOR_VERSION"
 
 # Restarts Dataproc Agent after successful initialization
-# WARNING: this function relies on undocumened and not officially supported Dataproc Agent
+# WARNING: this function relies on undocumented and not officially supported Dataproc Agent
 # "sentinel" files to determine successful Agent initialization and not guaranteed
 # to work in the future. Use at your own risk!
 restart_dataptoc_agent() {

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -59,3 +59,16 @@ fi
 
 update_connector "bigquery" "$BIGQUERY_CONNECTOR_VERSION"
 update_connector "gcs" "$GCS_CONNECTOR_VERSION"
+
+# Restarts Dataproc Agent after successful initialization
+restart_dataptoc_agent() {
+  while [[ ! -f /var/lib/google/dataproc/has_run_before ]]; do
+    sleep 1
+  done
+  if [[ ! -f /var/lib/google/dataproc/has_failed_before ]]; then
+    service google-dataproc-agent restart
+  fi
+}
+export -f restart_dataptoc_agent
+
+bash -c restart_dataptoc_agent & disown

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -62,18 +62,20 @@ update_connector "gcs" "$GCS_CONNECTOR_VERSION"
 
 # Restarts Dataproc Agent after successful initialization
 restart_dataptoc_agent() {
-  # Dataproc Agent should be restarted after initialization,
-  # that's why we need to wait until Dataproc Agent will create
-  # sentinel file that signals that initialization has finished
+  # Because Dataproc Agent should be restarted after initialization, we need to wait until
+  # it will create a sentinel file that signals initialization competition (success or failure)
   while [[ ! -f /var/lib/google/dataproc/has_run_before ]]; do
     sleep 1
   done
-  # If Dataproc Agent didn't create sentinel file that signals
-  # that initialization failed then restart Dataproc Agent
+  # If Dataproc Agent didn't create a sentinel file that signals initialization
+  # failure then it means that initialization succeded and it should be restarted
   if [[ ! -f /var/lib/google/dataproc/has_failed_before ]]; then
     service google-dataproc-agent restart
   fi
 }
 export -f restart_dataptoc_agent
 
+# Schedule asynchronous Dataproc Agent restart.
+# It could not be restarted sycnhronously because Dataproc Agent should be restarted
+# after its initialization, including init actions execution, has been completed.
 bash -c restart_dataptoc_agent & disown


### PR DESCRIPTION
Dataproc Agent needs to be restarted because it could have loaded classes from old GCS connector jar which could cause failures during job submission.