### PR TITLE
Add a check for schema compatibility to cloud-sql-proxy

### DIFF
--- a/cloud-sql-proxy/README.MD
+++ b/cloud-sql-proxy/README.MD
@@ -146,6 +146,23 @@ Google Cloud's key management service. You will only need to encrypt and provide
         --metadata "db-hive-password-uri=gs://<SECRETS_BUCKET>/hive-password.encrypted"
     ```
 
+8. Upgrading schema (create cluster step failed on new Dataproc version):
+
+    When changing Dataproc versions, metastore may detect schema as obsolete. In this case a schema upgrade may be necessary. Log into master node on a cluster with new Dataproc version, and run these commands:
+    
+    ```bash
+    $ /usr/lib/hive/bin/schematool -dbType mysql -info
+    Hive distribution version: 2.3.0
+    Metastore schema version: 2.1.0
+    org.apache.hadoop.hive.metastore.HiveMetaException: Metastore schema version is not compatible. Hive Version: 2.3.0, Database Schema Version: 2.1.0
+    *** schemaTool failed ***
+
+    User can upgrade their schema by running:
+    $ /usr/lib/hive/bin/schematool -dbType mysql -upgradeSchemaFrom <current-version>
+    ```
+
+    Now schema is updated. Please delete and recreate the cluster
+
 **Notes:**
 
 * If the cluster's service account has permission to decrypt the `root` or `hive` password, then any user that

--- a/cloud-sql-proxy/README.MD
+++ b/cloud-sql-proxy/README.MD
@@ -148,7 +148,9 @@ Google Cloud's key management service. You will only need to encrypt and provide
 
 8. Upgrading schema (create cluster step failed on new Dataproc version):
 
-    When changing Dataproc versions, metastore may detect schema as obsolete. In this case a schema upgrade may be necessary. Log into master node on a cluster with new Dataproc version, and run these commands:
+    When changing Dataproc versions, metastore may detect schema as obsolete. The initialization action log will include `*** schemaTool failed ***` and `Run /usr/lib/hive/bin/schematool -dbType mysql -upgradeSchemaFrom <schema-version> to upgrade the schema. Note that this may break Hive metastores that depend on the old schema'` messges.
+    
+    In this case a schema upgrade is necessary. Log into master node on a cluster with new Dataproc version, and run these commands:
     
     ```bash
     $ /usr/lib/hive/bin/schematool -dbType mysql -info

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -202,6 +202,9 @@ EOF
     echo "Service hive-metastore is not loaded"
   fi
 
+  # Check that metastore schema is compatible.
+  /usr/lib/hive/bin/schematool -dbType mysql -info
+
   # Validate it's functioning.
   if ! hive -e 'SHOW TABLES;' >& /dev/null; then
     err 'Failed to bring up Cloud SQL Metastore'

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -203,7 +203,8 @@ EOF
   fi
 
   # Check that metastore schema is compatible.
-  /usr/lib/hive/bin/schematool -dbType mysql -info
+  /usr/lib/hive/bin/schematool -dbType mysql -info || \
+      err 'Run /usr/lib/hive/bin/schematool -dbType mysql -upgradeSchemaFrom <schema-version> to upgrade the schema. Note that this may break Hive metastores that depend on the old schema'
 
   # Validate it's functioning.
   if ! hive -e 'SHOW TABLES;' >& /dev/null; then


### PR DESCRIPTION
When switching Dataproc versions, metastore schema may become incompatible. When this happens, we can use schematool to report a concise error and fail.

$ /usr/lib/hive/bin/schematool -dbType mysql -info
Hive distribution version:       2.3.0
Metastore schema version:        2.1.0
org.apache.hadoop.hive.metastore.HiveMetaException: Metastore schema version is not compatible. Hive Version: 2.3.0, Database Schema Version: 2.1.0
*** schemaTool failed ***

User can upgrade their schema by running:
$ /usr/lib/hive/bin/schematool -dbType mysql -upgradeSchemaFrom 2.1.0

I am not sure if automating upgrade is a welcome change. Could we potentially upgrade schema in a way that it could no longer be used with previous Dataproc versions?