### PR TITLE
skip hive metastore in cloud sql setup for masters other than master0 in HA mode

### DIFF
--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -224,7 +224,7 @@ EOF
       || err 'Failed to set mysql schema.'
   fi
 
-  run_validation
+  run_with_retries run_validation
 }
 
 function run_validation() {
@@ -243,8 +243,9 @@ function run_validation() {
   # Validate it's functioning.
   if ! beeline -u jdbc:hive2://localhost:10000 -e 'SHOW TABLES;' >& /dev/null; then
     err 'Failed to bring up Cloud SQL Metastore'
+  else
+    echo 'Cloud SQL Hive Metastore initialization succeeded' >&2
   fi
-  echo 'Cloud SQL Hive Metastore initialization succeeded' >&2
 
 }
 


### PR DESCRIPTION
When creating a HA cluster, mysql cli is uninstalled on all masters other than master0, so we can't use mysql cli to setup hive metastore on those nodes. Since all the masters point to the same db in cloud sql as the hive metastore, we need only master0 to setup the metastore, and the other masters only need to update "hive.metastore.warehouse.dir", which can be fetched using beeline to query hive server directly.