### PR TITLE
Fixes hanging beeline on dataproc version 1.0 #320.

### DIFF
--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -241,7 +241,7 @@ function run_validation() {
       err 'Run /usr/lib/hive/bin/schematool -dbType mysql -upgradeSchemaFrom <schema-version> to upgrade the schema. Note that this may break Hive metastores that depend on the old schema'
 
   # Validate it's functioning.
-  if ! beeline -u jdbc:hive2://localhost:10000 -e 'SHOW TABLES;' >& /dev/null; then
+  if ! timeout 60s beeline -u jdbc:hive2://localhost:10000 -e 'SHOW TABLES;' >& /dev/null; then
     err 'Failed to bring up Cloud SQL Metastore'
   else
     echo 'Cloud SQL Hive Metastore initialization succeeded' >&2


### PR DESCRIPTION
Using timeout command works fine on all dataproc versions. Fixes validation part that uses older beeline version available on dataproc 1.0.