### PR TITLE
Allow users to specify a custom Flink snapshot URL

### DIFF
--- a/flink/README.md
+++ b/flink/README.md
@@ -43,3 +43,4 @@ You can find more information about using initialization actions with Dataproc i
 
 * By default, a detached Flink YARN session is started for you. To find its application id, run `yarn application -list`.
 * The default session is configured to consume all YARN resources. If you want to submit multiple jobs in parallel or use transient sessions, you'll need to disable this default session. You can either fork this init script and set START_FLINK_YARN_SESSION_DEFAULT to `false`, or set the cluster metadata key `flink-start-yarn-session` to `false` when you create your cluster.
+* By default, flink is installed via apt.  However, a custom flink snapshot can be installed by specifying the `flink-snapshot-url` metadata key to a URL that points to a valid flink tarball.


### PR DESCRIPTION
In order to support Beam use cases, customers need to be able to install
flink versions other than the ones supported by apt.  To facilitate
this, this commit adds the metadata key `flink-snapshot-url` which, when
set, will be used to download a flink tarball from a custom address.

This commit also cleans up the call pattern a little by separating
flink configuration and invocation.  This is useful if the yarn
application needs to be killed and restarted for any reason.