### PR TITLE
Add Beam Job Service init action

### DIFF
--- a/beam/README.md
+++ b/beam/README.md
@@ -1,0 +1,52 @@
+# Beam Initialization Actions
+
+While Beam is primarily a SDK, jobs running under its portability framework
+require a job service to run correctly.  This directory contains a setup script
+to setup a properly configured beam job services.
+
+## Using This Initialization Action
+
+Use the `gcloud` command to create a new cluster with beam, flink, and docker
+enabled:
+
+```bash
+gcloud dataproc clusters create <CLUSTER_NAME> \
+--initialization-actions gs://dataproc-initialization-actions/flink/flink.sh,gs://dataproc-initialization-actions/docker/docker.sh,gs://dataproc-initialization-actions/beam/beam_job_service.sh \
+--image-version=1.2
+--metadata=flink-snapshot-url=https://archive.apache.org/dist/flink/flink-1.5.3/flink-1.5.3-bin-hadoop28-scala_2.11.tgz
+```
+
+Beam 2.7 requires Flink 1.5, which is not the default Flink version in Dataproc
+1.2.  Therefore users must specify a custom flink snapshot, as above.
+
+This will set up a Beam Job Service on port `8099` of the master node. You can 
+submit portable beam jobs against this port as normal. For example to run the Go 
+Wordcount example from the master node, one could upload the wordcount binary
+and then run:
+
+```bash
+./wordcount \
+  --runner flink \
+  --endpoint localhost:8099 \
+  --experiments beam_fn_api \
+  --output=<out> \
+  --container_image <image_repo>/go:v2.7.0
+```
+
+The Beam Job Service port will need to be opened if users wish to submit beam
+jobs from machines outside the cluster.  Please refer to the
+[guide](https://cloud.google.com/vpc/docs/using-firewalls) for instructions on
+how to accomplish this.
+
+## Metadata Variables
+
+The Beam init action uses the following metadata variables
+
+| Metadata Key | Default | Description |
+| --- | --- |
+| beam-artifacts-dir | [cluster staging bucket](https://cloud.google.com/dataproc/docs/guides/create-cluster#auto-created_staging_bucket) | A writeable GCS bucket that Beam can use to stage artifacts |
+| beam-job-service-snapshot | [snapshot](http://repo1.maven.org/maven2/org/apache/beam/beam-runners-flink_2.11-job-server/2.6.0/beam-runners-flink_2.11-job-server-2.6.0.jar) | The URL of a Beam job service snapshot |
+| beam-image-enable-pull | false | When set to true, the init action will attempt to pull beam worker images for efficient access later |
+| beam-image-version | v2.7.0 | The image version to use when selecting a tagged image |
+| beam-image-repository | apache.bintray.io/beam | The image repository root to pull images from. As of this writing (September 5th, 2018) these images have not been published yet.  Therefore it is recommended that users build and store their own images when using this init action. |
+

--- a/beam/beam_job_service.sh
+++ b/beam/beam_job_service.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+readonly LOCAL_JAR_NAME='beam-runners-flink_2.11-job-server.jar'
+readonly SERVICE_INSTALL_DIR='/usr/lib/beam-job-service'
+readonly SERVICE_WORKING_DIR='/var/lib/beam-job-service'
+readonly SERVICE_WORKING_USER='yarn'
+
+readonly ARTIFACTS_DIR_METADATA_KEY='beam-artifacts-dir'
+readonly RELEASE_SNAPSHOT_URL_METADATA_KEY="beam-job-service-snapshot"
+readonly RELEASE_SNAPSHOT_URL_DEFAULT="http://repo1.maven.org/maven2/org/apache/beam/beam-runners-flink_2.11-job-server/2.6.0/beam-runners-flink_2.11-job-server-2.6.0.jar"
+
+readonly BEAM_IMAGE_ENABLE_PULL_METADATA_KEY="beam-image-enable-pull"
+readonly BEAM_IMAGE_ENABLE_PULL_DEFAULT=false
+readonly BEAM_IMAGE_VERSION_METADATA_KEY="beam-image-version"
+readonly BEAM_IMAGE_VERSION_DEFAULT="v2.7.0"
+readonly BEAM_IMAGE_REPOSITORY_KEY="beam-image-repository"
+readonly BEAM_IMAGE_REPOSITORY_DEFAULT="apache.bintray.io/beam"
+
+
+readonly START_FLINK_YARN_SESSION_METADATA_KEY='flink-start-yarn-session'
+# Set this to true to start a flink yarn session at initialization time.
+readonly START_FLINK_YARN_SESSION_DEFAULT=true
+
+function is_master() {
+  local role="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+  if [[ "$role" == 'Master' ]] ; then
+    true
+  else
+    false
+  fi
+}
+
+function get_artifacts_dir() {
+  /usr/share/google/get_metadata_value "attributes/${ARTIFACTS_DIR_METADATA_KEY}" \
+    || echo "gs://$(/usr/share/google/get_metadata_value "attributes/dataproc-bucket")/beam-artifacts"
+}
+
+function download_snapshot() {
+  readonly snapshot_url="${1}"
+  readonly protocol="$(echo "${snapshot_url}" | head -c5)"
+  if [ "${protocol}" = "gs://" ]; then
+    gsutil cp "${snapshot_url}" "${LOCAL_JAR_NAME}"
+  else
+    curl -o "${LOCAL_JAR_NAME}" "${snapshot_url}"
+  fi
+}
+
+function flink_master_url() {
+  local start_flink_yarn_session="$(/usr/share/google/get_metadata_value \
+    "attributes/${START_FLINK_YARN_SESSION_METADATA_KEY}" \
+    || echo "${START_FLINK_YARN_SESSION_DEFAULT}")"
+  # TODO: delete this workaround when the beam job service is able to understand 
+  # flink in yarn mode.
+  if ${start_flink_yarn_session} ; then
+    # grab final field from the first yarn application that contains 'flink'
+    yarn application -list >&2 # Logging this here is useful for debugging potential failures
+    yarn application -list \
+      | grep -i 'flink' \
+      | head -n1 \
+      | awk -F $'\t' '{print $9}' \
+      | cut -c8-
+  else
+    echo "localhost:8081"
+  fi
+}
+
+function install_job_service() {
+  local master_url="$(/usr/share/google/get_metadata_value attributes/dataproc-master)"
+  local artifacts_dir="$(get_artifacts_dir)"
+  local release_snapshot_url="$(/usr/share/google/get_metadata_value \
+    "attributes/${RELEASE_SNAPSHOT_URL_METADATA_KEY}" \
+    || echo "${RELEASE_SNAPSHOT_URL_DEFAULT}")"
+
+  echo "Retrieving Beam Job Service snapshot from ${release_snapshot_url}"
+
+  local flink_master="$(flink_master_url)"
+  echo "resolved flink master to: '${master_url}'"
+
+  mkdir -p "${SERVICE_INSTALL_DIR}"
+  pushd "${SERVICE_INSTALL_DIR}"
+  download_snapshot "${release_snapshot_url}"
+  popd
+  mkdir -p "${SERVICE_WORKING_DIR}"
+  chown -R "${SERVICE_WORKING_USER}" "${SERVICE_WORKING_DIR}"
+
+  cat > "/etc/systemd/system/beam-job-service.service" <<EOF
+[Unit]
+Description=Beam Job Service
+After=default.target
+
+[Service]
+Type=simple
+User=${SERVICE_WORKING_USER}
+WorkingDirectory=${SERVICE_WORKING_DIR}
+ExecStart=/usr/bin/java \
+  -jar ${SERVICE_INSTALL_DIR}/${LOCAL_JAR_NAME} \
+  --job-host=${master_url}\
+  --artifacts-dir=${artifacts_dir} \
+  --flink-master-url=${flink_master}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable beam-job-service
+}
+
+function run_job_service() {
+  systemctl restart beam-job-service
+}
+
+function pull_beam_images() {
+  local beam_image_version="$(/usr/share/google/get_metadata_value \
+    "attributes/${BEAM_IMAGE_VERSION_METADATA_KEY}" \
+    || echo "${BEAM_IMAGE_VERSION_DEFAULT}")"
+  local image_repo="$(/usr/share/google/get_metadata_value \
+    "attributes/${BEAM_IMAGE_REPOSITORY_KEY}" \
+    || echo "${BEAM_IMAGE_REPOSITORY_DEFAULT}")"
+  sudo -u yarn -i docker pull "${image_repo}/go:${beam_image_version}"
+  sudo -u yarn -i docker pull "${image_repo}/python:${beam_image_version}"
+  sudo -u yarn -i docker pull "${image_repo}/java:${beam_image_version}"
+}
+
+function main() {
+  if [[ is_master ]]; then
+    install_job_service
+    run_job_service
+  fi
+
+  local pull_images="$(/usr/share/google/get_metadata_value \
+    "attributes/${BEAM_IMAGE_ENABLE_PULL_METADATA_KEY}" \
+    || echo "${RELEASE_SNAPSHOT_URL_METADATA_KEY}")"
+  if ${pull_images} ; then
+    pull_beam_images
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
This sets up a Beam Job Service on the master node.  It depends on Flink
and Docker being installed to function correctly.