### PR TITLE
Add Beam Job Service init action

### DIFF
--- a/beam/README.md
+++ b/beam/README.md
@@ -1,39 +1,31 @@
 # Beam Initialization Actions
 
-While Beam is primarily a SDK, jobs running under its portability framework
+While Apache Beam is primarily a SDK, jobs running under its portability framework
 require a job service to run correctly.  This directory contains a setup script
-to setup a properly configured beam job services.
+to properly configure beam job services.
 
 **WARNING:** The Beam portability framework is **under active development** and
 should not be used in a production context.
 
-Due to the current development status of Beam's portability framework, users are
-responsible for building and maintaining their own Beam artifacts manually.
-Instructions are included below.  The current development status of the Beam
-portability framework can be found
-[here](https://beam.apache.org/contribute/portability/#status).
+Due to the current development [status](https://beam.apache.org/contribute/portability/#status) of Beam's portability
+framework, users are responsible for building and maintaining their own Beam artifacts manually. Instructions are included below.
 
 ## Building Beam Artifacts
 
-There are two categories of artifacts that will need to be generated for this
-initialization action:
+You will generate two categories of artifacts for this initialization action:
 
-| Job Service | This microservice runs on the master node, accepting new beam jobs on port 8099.  It is configured to submit Beam jobs to Flink. |
-| Worker Container Images | These docker images are what run language-specific code on worker nodes. |
+| Job Service | This micro service runs on the master node, accepting new beam jobs on port 8099.  It is configured to submit Beam jobs to Apache Flink. |
+| Worker Container Images | These docker images run language-specific code on worker nodes. |
 
-Throughout the build process, we will refer to the following terms, which will
-need to be substituted into build commands if building manually.  In bash, one
-convenient way to use them is to set environment variables using `export
-<term>=<value>`.
+When building manually, substitute the following terms into build commands. In bash, set environment variables using `export <term>=<value>`.
 
-| `BEAM_JOB_SERVICE_DESTINATION` | A GCS directory path accessible by both the build machine and the cluster to be created. |
+| `BEAM_JOB_SERVICE_DESTINATION` | A Cloud Storage directory path accessible by both the build machine and the cluster to be created. |
 | `BEAM_CONTAINER_IMAGE_DESTINATION` | A Docker repository path prefix accessible by both the build machine and the cluster to be created. |
 | `BEAM_SOURCE_VERSION` | A tag, branch, or commit hash in the Beam source repositories to build artifacts from. (default: `master`) |
 
 ### Automated Build
 
-The `util` directory contains a script to assist in building Beam artifacts.
-From this directory on a build machine, you can invoke it with:
+You can invoke a helper script from `util` directory to build Beam artifacts.
 
 ```bash
 bash ./util/build-beam-artifacts.sh <BEAM_JOB_SERVICE_DESTINATION> <BEAM_CONTAINER_IMAGE_DESTINATION> [<BEAM_SOURCE_VERSION>]
@@ -41,8 +33,7 @@ bash ./util/build-beam-artifacts.sh <BEAM_JOB_SERVICE_DESTINATION> <BEAM_CONTAIN
 
 ### Manual Build
 
-Alternatively, developers can build the necessary artifacts manually.  To get
-started, first clone the beam source code into a working directory.
+To get started, clone the beam source code into a working directory.
 
 ```bash
 git clone https://github.com/apache/beam.git
@@ -52,15 +43,13 @@ git checkout ${BEAM_SOURCE_VERSION}
 
 #### Build the Job Service
 
-This step will build a standalone job service jar, and upload it to that path
-for use during cluster creation.
+Next, build a standalone job service jar.
 
 ```bash
 ./gradlew :beam-runners-flink_2.11-job-server:shadowJar
 ```
 
-After the jar has been built, it will need to be uploaded to a GCS path that
-clusters can access during initialization.
+Then, upload the jar to a Cloud Storage path that clusters can access during initialization.
 
 ```bash
 gsutil cp \
@@ -70,16 +59,17 @@ gsutil cp \
 
 #### Build the Worker Container Images
 
-This step will build the docker images used by Beam worker tasks.
+Build the docker images used by Beam worker tasks.
 
 ```bash
 ./gradlew docker
 ```
 
-This will build a number of docker images with names that look like
-`<USER>-docker-apache.bintray.io/beam/<LANGUAGE>`.  These need to be renamed and
-pushed to a docker repository path that clusters can access during
-initialization.  We recommend tagging these images with the
+Docker images names are generated in the following format:
+`<USER>-docker-apache.bintray.io/beam/<LANGUAGE>`. 
+
+Rename and push the images to a docker repository path that clusters can access during
+initialization.  As a best practice, tag the images with the
 `BEAM_SOURCE_VERSION` they were generated from.
 
 ```bash
@@ -89,30 +79,39 @@ docker tag \
 docker push <BEAM_CONTAINER_IMAGE_DESTINATION>/<LANGUAGE>:<BEAM_SOURCE_VERSION>
 ```
 
-## Creating a Cluster
+## Create a Beam Cluster
 
-Running a Beam cluster currently requires the following initialization actions:
+You create a Beam cluster by calling the Cloud Dataproc clusters create command with the following initialization actions:
 
   - `docker/docker.sh`
   - `flink/flink.sh`
   - `beam/beam_job_service.sh`
 
-In addition, a number of metadata variables need to be set correctly.
+The Beam `beam_job_service` and `flink/flink.sh` initialization actions use the following
+[metadata variables](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/init-actions#passing_arguments_to_initialization_actions):
+
+| Metadata Key | Default | Description |
+| --- | --- |
+| beam-job-service-snapshot | [v2.6.0](http://repo1.maven.org/maven2/org/apache/beam/beam-runners-flink_2.11-job-server/2.6.0/beam-runners-flink_2.11-job-server-2.6.0.jar) | The URL or GCS bucket of a Beam job service snapshot. |
+| beam-image-enable-pull | false | When set to true, the init action will attempt to pull beam worker images for efficient access later |
+| beam-image-version | master | The image version to use when selecting a tagged image |
+| beam-image-repository | apache.bintray.io/beam | The image repository root to pull images from. As of September 12th, 2018, these images have not been published yet.  Therefore it is recommended that users build and store their own images when using this init action. |
+| flink-start-yarn-session | ???? |
+| flink-snapshot-url | URL to a Flink snapshot.
+
+You should explicitly set the Beam and Flink metadata variables (use a script as shown later).
 
 | Metadata Key | Value |
 | --- | --- |
-| beam-job-service-snapshot | The GCS path of your JobService jar (see above) |
-| beam-image-enable-pull | `true` |
-| beam-image-repository | `<BEAM_CONTAINER_IMAGE_DESTINATION>` (see above) |
+| beam-job-service-snapshot | The Cloud Storage path of your JobService jar (see above) |
+| beam-image-enable-pull | `true` | ??? Description ???
 | beam-image-version | the tag used for container images (default: `latest`) |
-| flink-start-yarn-session | `true` |
-| flink-snapshot-url | URL to a flink 1.5 snapshot such as [this one](https://archive.apache.org/dist/flink/flink-1.5.3/flink-1.5.3-bin-hadoop28-scala_2.11.tgz) |
+| beam-image-repository | `<BEAM_CONTAINER_IMAGE_DESTINATION>` (see above) |
+| flink-start-yarn-session | `true` | ??? Description ???
+| flink-snapshot-url | URL to a flink 1.5 snapshot, such as
+[https://archive.apache.org/dist/flink/flink-1.5.3/flink-1.5.3-bin-hadoop28-scala_2.11.tgz](https://archive.apache.org/dist/flink/flink-1.5.3/flink-1.5.3-bin-hadoop28-scala_2.11.tgz). You must set this variable since Beam 2.7 requires Flink 1.5, but Cloud Dataproc uses version 1.2 as a default. |
 
-Beam 2.7 requires Flink 1.5, which is not the default Flink version in Dataproc
-1.2.  Therefore users must specify a custom flink snapshot.
-
-In practice, the best way to handle this many metadata values is through a
-script such as this one:
+The recommended practice is to use a script to set variables and create the Beam cluster.
 
 TODO: anonymize this
 ```bash
@@ -135,10 +134,7 @@ gcloud dataproc clusters create "${CLUSTER_NAME}" \
   --metadata="${METADATA}"
 ```
 
-This will set up a Beam Job Service on port `8099` of the master node. You can 
-submit portable beam jobs against this port as normal. For example to run the Go 
-Wordcount example from the master node, one could upload the wordcount job
-binary and then run:
+The Beam Job Service runs on port `8099` of the master node. You can submit portable Beam jobs against this port. For example, to run the [Go Wordcount example](????link ????) on the master node, upload the wordcount job binary, and then run:
 
 ```bash
 ./wordcount \
@@ -149,21 +145,5 @@ binary and then run:
   --container_image <BEAM_CONTAINER_DESTINATION>/go:<BEAM_SOURCE_VERSION>
 ```
 
-The Beam Job Service port will need to be opened if users wish to submit beam
-jobs from machines outside the cluster.  Please refer to the
-[guide](https://cloud.google.com/vpc/docs/using-firewalls) for instructions on
-how to accomplish this.
-
-## Metadata Variables
-
-The Beam init action uses the following metadata variables.  It is **highly
-recommended** that users build Beam artifacts as described above, and specify
-them explicitly by setting these metadata keys to custom values.
-
-| Metadata Key | Default | Description |
-| --- | --- |
-| beam-job-service-snapshot | [v2.6.0](http://repo1.maven.org/maven2/org/apache/beam/beam-runners-flink_2.11-job-server/2.6.0/beam-runners-flink_2.11-job-server-2.6.0.jar) | The URL or GCS bucket of a Beam job service snapshot. |
-| beam-image-enable-pull | false | When set to true, the init action will attempt to pull beam worker images for efficient access later |
-| beam-image-version | master | The image version to use when selecting a tagged image |
-| beam-image-repository | apache.bintray.io/beam | The image repository root to pull images from. As of September 12th, 2018, these images have not been published yet.  Therefore it is recommended that users build and store their own images when using this init action. |
-
+The Beam Job Service port must be opened to submit beam jobs from machines outside the cluster (see
+[Using Firewall Rules](https://cloud.google.com/vpc/docs/using-firewalls) for instructions)).

--- a/beam/README.md
+++ b/beam/README.md
@@ -1,0 +1,169 @@
+# Beam Initialization Actions
+
+While Beam is primarily a SDK, jobs running under its portability framework
+require a job service to run correctly.  This directory contains a setup script
+to setup a properly configured beam job services.
+
+**WARNING:** The Beam portability framework is **under active development** and
+should not be used in a production context.
+
+Due to the current development status of Beam's portability framework, users are
+responsible for building and maintaining their own Beam artifacts manually.
+Instructions are included below.  The current development status of the Beam
+portability framework can be found
+[here](https://beam.apache.org/contribute/portability/#status).
+
+## Building Beam Artifacts
+
+There are two categories of artifacts that will need to be generated for this
+initialization action:
+
+| Job Service | This microservice runs on the master node, accepting new beam jobs on port 8099.  It is configured to submit Beam jobs to Flink. |
+| Worker Container Images | These docker images are what run language-specific code on worker nodes. |
+
+Throughout the build process, we will refer to the following terms, which will
+need to be substituted into build commands if building manually.  In bash, one
+convenient way to use them is to set environment variables using `export
+<term>=<value>`.
+
+| `BEAM_JOB_SERVICE_DESTINATION` | A GCS directory path accessible by both the build machine and the cluster to be created. |
+| `BEAM_CONTAINER_IMAGE_DESTINATION` | A Docker repository path prefix accessible by both the build machine and the cluster to be created. |
+| `BEAM_SOURCE_VERSION` | A tag, branch, or commit hash in the Beam source repositories to build artifacts from. (default: `master`) |
+
+### Automated Build
+
+The `util` directory contains a script to assist in building Beam artifacts.
+From this directory on a build machine, you can invoke it with:
+
+```bash
+bash ./util/build-beam-artifacts.sh <BEAM_JOB_SERVICE_DESTINATION> <BEAM_CONTAINER_IMAGE_DESTINATION> [<BEAM_SOURCE_VERSION>]
+```
+
+### Manual Build
+
+Alternatively, developers can build the necessary artifacts manually.  To get
+started, first clone the beam source code into a working directory.
+
+```bash
+git clone https://github.com/apache/beam.git
+cd beam
+git checkout ${BEAM_SOURCE_VERSION}
+```
+
+#### Build the Job Service
+
+This step will build a standalone job service jar, and upload it to that path
+for use during cluster creation.
+
+```bash
+./gradlew :beam-runners-flink_2.11-job-server:shadowJar
+```
+
+After the jar has been built, it will need to be uploaded to a GCS path that
+clusters can access during initialization.
+
+```bash
+gsutil cp \
+  ./runners/flink/job-server/build/libs/beam-runners-flink_2.11-job-server-*-SNAPSHOT.jar \
+  <BEAM_JOB_SERVICE_DESTINATION>/beam-runners-flink_2.11-job-server-latest-SNAPSHOT.jar
+```
+
+#### Build the Worker Container Images
+
+This step will build the docker images used by Beam worker tasks.
+
+```bash
+./gradlew docker
+```
+
+This will build a number of docker images with names that look like
+`<USER>-docker-apache.bintray.io/beam/<LANGUAGE>`.  These need to be renamed and
+pushed to a docker repository path that clusters can access during
+initialization.  We recommend tagging these images with the
+`BEAM_SOURCE_VERSION` they were generated from.
+
+```bash
+docker tag \
+  <USER>-docker-apache.bintray.io/beam/<LANGUAGE> \
+  <BEAM_CONTAINER_IMAGE_DESTINATION>/<LANGUAGE>:<BEAM_SOURCE_VERSION>
+docker push <BEAM_CONTAINER_IMAGE_DESTINATION>/<LANGUAGE>:<BEAM_SOURCE_VERSION>
+```
+
+## Creating a Cluster
+
+Running a Beam cluster currently requires the following initialization actions:
+
+  - `docker/docker.sh`
+  - `flink/flink.sh`
+  - `beam/beam_job_service.sh`
+
+In addition, a number of metadata variables need to be set correctly.
+
+| Metadata Key | Value |
+| --- | --- |
+| beam-job-service-snapshot | The GCS path of your JobService jar (see above) |
+| beam-image-enable-pull | `true` |
+| beam-image-repository | `<BEAM_CONTAINER_IMAGE_DESTINATION>` (see above) |
+| beam-image-version | the tag used for container images (default: `latest`) |
+| flink-start-yarn-session | `true` |
+| flink-snapshot-url | URL to a flink 1.5 snapshot such as [this one](https://archive.apache.org/dist/flink/flink-1.5.3/flink-1.5.3-bin-hadoop28-scala_2.11.tgz) |
+
+Beam 2.7 requires Flink 1.5, which is not the default Flink version in Dataproc
+1.2.  Therefore users must specify a custom flink snapshot.
+
+In practice, the best way to handle this many metadata values is through a
+script such as this one:
+
+TODO: anonymize this
+```bash
+CLUSTER_NAME="$1
+INIT_BUCKET="gs://dataproc-initialization-actions"
+INIT_ACTIONS="${INIT_BUCKET}/docker/docker.sh"
+INIT_ACTIONS+=",${INIT_BUCKET}/flink/flink.sh"
+INIT_ACTIONS+=",${INIT_BUCKET}/beam/beam_job_service.sh"
+FLINK_SNAPSHOT="https://archive.apache.org/dist/flink/flink-1.5.3/flink-1.5.3-bin-hadoop28-scala_2.11.tgz"
+METADATA="beam-job-service-snapshot=<...>"
+METADATA+=",beam-image-enable-pull=true"
+METADATA+=",beam-image-repository=<...>"
+METADATA+=",beam-image-version=latest"
+METADATA+=",flink-start-yarn-session=true"
+METADATA+=",flink-snapshot-url=${FLINK_SNAPSHOT}"
+
+gcloud dataproc clusters create "${CLUSTER_NAME}" \
+  --initialization-actions="${INIT_ACTIONS}" \
+  --image-version="1.2" \
+  --metadata="${METADATA}"
+```
+
+This will set up a Beam Job Service on port `8099` of the master node. You can 
+submit portable beam jobs against this port as normal. For example to run the Go 
+Wordcount example from the master node, one could upload the wordcount job
+binary and then run:
+
+```bash
+./wordcount \
+  --runner flink \
+  --endpoint localhost:8099 \
+  --experiments beam_fn_api \
+  --output=<out> \
+  --container_image <BEAM_CONTAINER_DESTINATION>/go:<BEAM_SOURCE_VERSION>
+```
+
+The Beam Job Service port will need to be opened if users wish to submit beam
+jobs from machines outside the cluster.  Please refer to the
+[guide](https://cloud.google.com/vpc/docs/using-firewalls) for instructions on
+how to accomplish this.
+
+## Metadata Variables
+
+The Beam init action uses the following metadata variables.  It is **highly
+recommended** that users build Beam artifacts as described above, and specify
+them explicitly by setting these metadata keys to custom values.
+
+| Metadata Key | Default | Description |
+| --- | --- |
+| beam-job-service-snapshot | [v2.6.0](http://repo1.maven.org/maven2/org/apache/beam/beam-runners-flink_2.11-job-server/2.6.0/beam-runners-flink_2.11-job-server-2.6.0.jar) | The URL or GCS bucket of a Beam job service snapshot. |
+| beam-image-enable-pull | false | When set to true, the init action will attempt to pull beam worker images for efficient access later |
+| beam-image-version | master | The image version to use when selecting a tagged image |
+| beam-image-repository | apache.bintray.io/beam | The image repository root to pull images from. As of September 12th, 2018, these images have not been published yet.  Therefore it is recommended that users build and store their own images when using this init action. |
+

--- a/beam/README.md
+++ b/beam/README.md
@@ -24,7 +24,7 @@ You will generate two categories of artifacts for this initialization action:
 When building manually, substitute the following terms into build commands. In
 bash, set environment variables using `export <term>=<value>`.
 
-| `beam_DESTINATION` | A Cloud Storage directory path accessible by both the build machine and the cluster to be created. |
+| `BEAM_JOB_SERVICE_DESTINATION` | A Cloud Storage directory path accessible by both the build machine and the cluster to be created. |
 | `BEAM_CONTAINER_IMAGE_DESTINATION` | A Docker repository path prefix accessible by both the build machine and the cluster to be created. |
 | `BEAM_SOURCE_VERSION` | A tag, branch, or commit hash in the Beam source repositories to build artifacts from. (default: `master`) |
 
@@ -33,7 +33,7 @@ bash, set environment variables using `export <term>=<value>`.
 You can invoke a helper script from `util` directory to build Beam artifacts.
 
 ```bash
-bash ./util/build-beam-artifacts.sh <beam_DESTINATION> <BEAM_CONTAINER_IMAGE_DESTINATION> [<BEAM_SOURCE_VERSION>]
+bash ./util/build-beam-artifacts.sh <BEAM_JOB_SERVICE_DESTINATION> <BEAM_CONTAINER_IMAGE_DESTINATION> [<BEAM_SOURCE_VERSION>]
 ```
 
 ### Manual Build
@@ -60,7 +60,7 @@ initialization.
 ```bash
 gsutil cp \
   ./runners/flink/job-server/build/libs/beam-runners-flink_2.11-job-server-*-SNAPSHOT.jar \
-  <beam_DESTINATION>/beam-runners-flink_2.11-job-server-latest-SNAPSHOT.jar
+  <BEAM_JOB_SERVICE_DESTINATION>/beam-runners-flink_2.11-job-server-latest-SNAPSHOT.jar
 ```
 
 #### Build the Worker Container Images

--- a/beam/beam.sh
+++ b/beam/beam.sh
@@ -7,7 +7,7 @@ readonly SERVICE_INSTALL_DIR='/usr/lib/beam-job-service'
 readonly SERVICE_WORKING_DIR='/var/lib/beam-job-service'
 readonly SERVICE_WORKING_USER='yarn'
 
-readonly ARTIFACTS_DIR_METADATA_KEY='beam-artifacts-dir'
+readonly ARTIFACTS_GCS_PATH_METADATA_KEY='beam-artifacts-gcs-path'
 readonly RELEASE_SNAPSHOT_URL_METADATA_KEY="beam-job-service-snapshot"
 readonly RELEASE_SNAPSHOT_URL_DEFAULT="http://repo1.maven.org/maven2/org/apache/beam/beam-runners-flink_2.11-job-server/2.6.0/beam-runners-flink_2.11-job-server-2.6.0.jar"
 
@@ -33,7 +33,7 @@ function is_master() {
 }
 
 function get_artifacts_dir() {
-  /usr/share/google/get_metadata_value "attributes/${ARTIFACTS_DIR_METADATA_KEY}" \
+  /usr/share/google/get_metadata_value "attributes/${ARTIFACTS_GCS_PATH_METADATA_KEY}" \
     || echo "gs://$(/usr/share/google/get_metadata_value "attributes/dataproc-bucket")/beam-artifacts"
 }
 
@@ -75,7 +75,7 @@ function install_job_service() {
   echo "Retrieving Beam Job Service snapshot from ${release_snapshot_url}"
 
   local flink_master="$(flink_master_url)"
-  echo "resolved flink master to: '${master_url}'"
+  echo "Resolved flink master to: '${master_url}'"
 
   mkdir -p "${SERVICE_INSTALL_DIR}"
   pushd "${SERVICE_INSTALL_DIR}"

--- a/beam/beam_job_service.sh
+++ b/beam/beam_job_service.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+readonly LOCAL_JAR_NAME='beam-runners-flink_2.11-job-server.jar'
+readonly SERVICE_INSTALL_DIR='/usr/lib/beam-job-service'
+readonly SERVICE_WORKING_DIR='/var/lib/beam-job-service'
+readonly SERVICE_WORKING_USER='yarn'
+
+readonly ARTIFACTS_DIR_METADATA_KEY='beam-artifacts-dir'
+readonly RELEASE_SNAPSHOT_URL_METADATA_KEY="beam-job-service-snapshot"
+readonly RELEASE_SNAPSHOT_URL_DEFAULT="http://repo1.maven.org/maven2/org/apache/beam/beam-runners-flink_2.11-job-server/2.6.0/beam-runners-flink_2.11-job-server-2.6.0.jar"
+
+readonly BEAM_IMAGE_ENABLE_PULL_METADATA_KEY="beam-image-enable-pull"
+readonly BEAM_IMAGE_ENABLE_PULL_DEFAULT=false
+readonly BEAM_IMAGE_VERSION_METADATA_KEY="beam-image-version"
+readonly BEAM_IMAGE_VERSION_DEFAULT="master"
+readonly BEAM_IMAGE_REPOSITORY_KEY="beam-image-repository"
+readonly BEAM_IMAGE_REPOSITORY_DEFAULT="apache.bintray.io/beam"
+
+
+readonly START_FLINK_YARN_SESSION_METADATA_KEY='flink-start-yarn-session'
+# Set this to true to start a flink yarn session at initialization time.
+readonly START_FLINK_YARN_SESSION_DEFAULT=true
+
+function is_master() {
+  local role="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+  if [[ "$role" == 'Master' ]] ; then
+    true
+  else
+    false
+  fi
+}
+
+function get_artifacts_dir() {
+  /usr/share/google/get_metadata_value "attributes/${ARTIFACTS_DIR_METADATA_KEY}" \
+    || echo "gs://$(/usr/share/google/get_metadata_value "attributes/dataproc-bucket")/beam-artifacts"
+}
+
+function download_snapshot() {
+  readonly snapshot_url="${1}"
+  readonly protocol="$(echo "${snapshot_url}" | head -c5)"
+  if [ "${protocol}" = "gs://" ]; then
+    gsutil cp "${snapshot_url}" "${LOCAL_JAR_NAME}"
+  else
+    curl -o "${LOCAL_JAR_NAME}" "${snapshot_url}"
+  fi
+}
+
+function flink_master_url() {
+  local start_flink_yarn_session="$(/usr/share/google/get_metadata_value \
+    "attributes/${START_FLINK_YARN_SESSION_METADATA_KEY}" \
+    || echo "${START_FLINK_YARN_SESSION_DEFAULT}")"
+  # TODO: delete this workaround when the beam job service is able to understand 
+  # flink in yarn mode.
+  if ${start_flink_yarn_session} ; then
+    # grab final field from the first yarn application that contains 'flink'
+    yarn application -list >&2 # Logging this here is useful for debugging potential failures
+    yarn application -list \
+      | grep -i 'flink' \
+      | head -n1 \
+      | awk -F $'\t' '{print $9}' \
+      | cut -c8-
+  else
+    echo "localhost:8081"
+  fi
+}
+
+function install_job_service() {
+  local master_url="$(/usr/share/google/get_metadata_value attributes/dataproc-master)"
+  local artifacts_dir="$(get_artifacts_dir)"
+  local release_snapshot_url="$(/usr/share/google/get_metadata_value \
+    "attributes/${RELEASE_SNAPSHOT_URL_METADATA_KEY}" \
+    || echo "${RELEASE_SNAPSHOT_URL_DEFAULT}")"
+
+  echo "Retrieving Beam Job Service snapshot from ${release_snapshot_url}"
+
+  local flink_master="$(flink_master_url)"
+  echo "resolved flink master to: '${master_url}'"
+
+  mkdir -p "${SERVICE_INSTALL_DIR}"
+  pushd "${SERVICE_INSTALL_DIR}"
+  download_snapshot "${release_snapshot_url}"
+  popd
+  mkdir -p "${SERVICE_WORKING_DIR}"
+  chown -R "${SERVICE_WORKING_USER}" "${SERVICE_WORKING_DIR}"
+
+  cat > "/etc/systemd/system/beam-job-service.service" <<EOF
+[Unit]
+Description=Beam Job Service
+After=default.target
+
+[Service]
+Type=simple
+User=${SERVICE_WORKING_USER}
+WorkingDirectory=${SERVICE_WORKING_DIR}
+ExecStart=/usr/bin/java \
+  -jar ${SERVICE_INSTALL_DIR}/${LOCAL_JAR_NAME} \
+  --job-host=${master_url}\
+  --artifacts-dir=${artifacts_dir} \
+  --flink-master-url=${flink_master}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable beam-job-service
+}
+
+function run_job_service() {
+  systemctl restart beam-job-service
+}
+
+function pull_beam_images() {
+  local beam_image_version="$(/usr/share/google/get_metadata_value \
+    "attributes/${BEAM_IMAGE_VERSION_METADATA_KEY}" \
+    || echo "${BEAM_IMAGE_VERSION_DEFAULT}")"
+  local image_repo="$(/usr/share/google/get_metadata_value \
+    "attributes/${BEAM_IMAGE_REPOSITORY_KEY}" \
+    || echo "${BEAM_IMAGE_REPOSITORY_DEFAULT}")"
+  sudo -u yarn -i docker pull "${image_repo}/go:${beam_image_version}"
+  sudo -u yarn -i docker pull "${image_repo}/python:${beam_image_version}"
+  sudo -u yarn -i docker pull "${image_repo}/java:${beam_image_version}"
+}
+
+function main() {
+  if [[ is_master ]]; then
+    install_job_service
+    run_job_service
+  fi
+
+  local pull_images="$(/usr/share/google/get_metadata_value \
+    "attributes/${BEAM_IMAGE_ENABLE_PULL_METADATA_KEY}" \
+    || echo "${RELEASE_SNAPSHOT_URL_METADATA_KEY}")"
+  if ${pull_images} ; then
+    pull_beam_images
+  fi
+}
+
+main "$@"

--- a/beam/beam_job_service.sh
+++ b/beam/beam_job_service.sh
@@ -55,7 +55,6 @@ function flink_master_url() {
   # flink in yarn mode.
   if ${start_flink_yarn_session} ; then
     # grab final field from the first yarn application that contains 'flink'
-    yarn application -list >&2 # Logging this here is useful for debugging potential failures
     yarn application -list \
       | grep -i 'flink' \
       | head -n1 \
@@ -118,6 +117,8 @@ function pull_beam_images() {
   local image_repo="$(/usr/share/google/get_metadata_value \
     "attributes/${BEAM_IMAGE_REPOSITORY_KEY}" \
     || echo "${BEAM_IMAGE_REPOSITORY_DEFAULT}")"
+  # Pull beam images with `sudo -i` since if pulling from GCR, yarn will be
+  # configured with GCR authorization
   sudo -u yarn -i docker pull "${image_repo}/go:${beam_image_version}"
   sudo -u yarn -i docker pull "${image_repo}/python:${beam_image_version}"
   sudo -u yarn -i docker pull "${image_repo}/java:${beam_image_version}"
@@ -131,7 +132,7 @@ function main() {
 
   local pull_images="$(/usr/share/google/get_metadata_value \
     "attributes/${BEAM_IMAGE_ENABLE_PULL_METADATA_KEY}" \
-    || echo "${RELEASE_SNAPSHOT_URL_METADATA_KEY}")"
+    || echo "${BEAM_IMAGE_ENABLE_PULL_DEFAULT}")"
   if ${pull_images} ; then
     pull_beam_images
   fi

--- a/beam/util/build-beam-artifacts.sh
+++ b/beam/util/build-beam-artifacts.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+if [ "$#" -lt 2 ] ; then
+  echo "Usage: $0 <BEAM_JOB_SERVICE_DESTINATION> <BEAM_CONTAINER_IMAGE_DESTINATION> [<BEAM_SOURCE_VERSION>]" >&2
+  exit 1
+fi
+
+readonly BEAM_JOB_SERVICE_DESTINATION="$1"
+readonly BEAM_CONTAINER_IMAGE_DESTINATION="$2"
+readonly BEAM_SOURCE_VERSION="${3:-master}"
+
+function build_job_service() {
+  ./gradlew :beam-runners-flink_2.11-job-server:shadowJar
+  gsutil cp \
+    ./runners/flink/job-server/build/libs/beam-runners-flink_2.11-job-server-*-SNAPSHOT.jar \
+    ${BEAM_JOB_SERVICE_DESTINATION}/beam-runners-flink_2.11-job-server-${BEAM_SOURCE_VERSION}-SNAPSHOT.jar
+}
+
+function build_container() {
+  ./gradlew docker
+  local images=($(docker images \
+    | grep '.*-docker-apache' \
+    | awk '{print $1}'))
+  for image in ${images} ; do
+    local image_destination="${BEAM_CONTAINER_IMAGE_DESTINATION}/$(basename ${image}):${BEAM_SOURCE_VERSION}"
+    docker tag $image:latest ${image_destination}
+    docker push ${image_destination}
+  done
+}
+
+function main() {
+  local workdir=$(mktemp -d)
+  pushd ${workdir}
+  git clone https://github.com/apache/beam.git
+  pushd beam
+  git checkout "${BEAM_SOURCE_VERSION}"
+  ./gradlew clean
+  build_job_service
+  build_container
+  popd
+}
+
+main "$@"

--- a/beam/util/build-beam-artifacts.sh
+++ b/beam/util/build-beam-artifacts.sh
@@ -3,7 +3,7 @@
 set -exuo pipefail
 
 if [ "$#" -lt 2 ] ; then
-  echo "Usage: $0 <BEAM_JOB_SERVICE_DESTINATION> <BEAM_CONTAINER_IMAGE_DESTINATION> [<BEAM_SOURCE_VERSION>]" >&2
+  echo "Usage: $0 <BEAM_JOB_SERVICE_DESTINATION> <BEAM_CONTAINER_IMAGE_DESTINATION> [<BEAM_SOURCE_VERSION> [<BEAM_SOURCE_DIRECTORY>]]" >&2
   exit 1
 fi
 
@@ -31,10 +31,15 @@ function build_container() {
 }
 
 function main() {
-  local workdir=$(mktemp -d)
-  pushd ${workdir}
-  git clone https://github.com/apache/beam.git
-  pushd beam
+  if [[ $# -eq 4 ]] ; then
+    # if there is a 4th argument, use it as the beam source directory
+    pushd "$4"
+  else
+    local workdir=$(mktemp -d)
+    pushd ${workdir}
+    git clone https://github.com/apache/beam.git
+    pushd beam
+  fi
   git checkout "${BEAM_SOURCE_VERSION}"
   ./gradlew clean
   build_job_service


### PR DESCRIPTION
This sets up a Beam Job Service on the master node.  It depends on Flink
and Docker being installed to function correctly.

The Beam team has advised us that Beam is not in a place where the portability
framework can be considered production ready, and as a result the stable
snapshots cannot be relied on.  They advise instead that for the time being,
users build their own Job Service and Worker Image artifacts.  This PR includes
both an init action for the job service, and an automated build script.
Build instructions are also available in the README.