### PR TITLE
Fix beam artifact path to use hdfs over the gcs staging bucket

### DIFF
--- a/beam/README.md
+++ b/beam/README.md
@@ -99,7 +99,7 @@ The Beam `beam` and `flink/flink.sh` initialization actions use the following
 | Metadata Key | Default | Description |
 | ------------ | ------- | ----------- |
 | beam-job-service-snapshot | [v2.6.0](http://repo1.maven.org/maven2/org/apache/beam/beam-runners-flink_2.11-job-server/2.6.0/beam-runners-flink_2.11-job-server-2.6.0.jar) | The Cloud Storage path of your JobService jar (see above) |
-| beam-artifacts-gcs-path | `<cluster staging bucket>` | A cluster-writeable GCS path to store beam artifacts under |
+| beam-artifacts-dfs-path | `hdfs://tmp/beam-artifacts` | A cluster-writeable path on a distributed file system such as HDFS or GCS that can store runtime beam artifacts |
 | beam-image-enable-pull | false | When set to true, the init action will attempt to pull beam worker images for efficient access later |
 | beam-image-version | master | The image version to use when selecting a tagged image |
 | beam-image-repository | apache.bintray.io/beam | The image repository root to pull images from. As of September 12th, 2018, these images have not been published yet.  Therefore it is recommended that you build and store their own images when using this init action. |

--- a/beam/beam.sh
+++ b/beam/beam.sh
@@ -7,7 +7,8 @@ readonly SERVICE_INSTALL_DIR='/usr/lib/beam-job-service'
 readonly SERVICE_WORKING_DIR='/var/lib/beam-job-service'
 readonly SERVICE_WORKING_USER='yarn'
 
-readonly ARTIFACTS_GCS_PATH_METADATA_KEY='beam-artifacts-gcs-path'
+readonly ARTIFACTS_DFS_PATH_METADATA_KEY='beam-artifacts-dfs-path'
+readonly ARTIFACTS_DFS_PATH_DEFAULT='hdfs://tmp/beam-artifacts'
 readonly RELEASE_SNAPSHOT_URL_METADATA_KEY="beam-job-service-snapshot"
 readonly RELEASE_SNAPSHOT_URL_DEFAULT="http://repo1.maven.org/maven2/org/apache/beam/beam-runners-flink_2.11-job-server/2.6.0/beam-runners-flink_2.11-job-server-2.6.0.jar"
 
@@ -30,11 +31,6 @@ function is_master() {
   else
     false
   fi
-}
-
-function get_artifacts_dir() {
-  /usr/share/google/get_metadata_value "attributes/${ARTIFACTS_GCS_PATH_METADATA_KEY}" \
-    || echo "gs://$(/usr/share/google/get_metadata_value "attributes/dataproc-bucket")/beam-artifacts"
 }
 
 function download_snapshot() {
@@ -67,7 +63,9 @@ function flink_master_url() {
 
 function install_job_service() {
   local master_url="$(/usr/share/google/get_metadata_value attributes/dataproc-master)"
-  local artifacts_dir="$(get_artifacts_dir)"
+  local artifacts_dir="$(/usr/share/google/get_metadata_value \
+    "attributes/${ARTIFACTS_DFS_PATH_METADATA_KEY}" \
+    || echo "${ARTIFACTS_DFS_PATH_DEFAULT}")"
   local release_snapshot_url="$(/usr/share/google/get_metadata_value \
     "attributes/${RELEASE_SNAPSHOT_URL_METADATA_KEY}" \
     || echo "${RELEASE_SNAPSHOT_URL_DEFAULT}")"


### PR DESCRIPTION
It turns out that the gcs staging bucket is not managed the way I
thought, making hdfs a better fit for beam artifacts.