### PR TITLE
Provide default values (and self-signed certificate) if user does not specify them in secure/secure.sh.

### DIFF
--- a/secure/README.md
+++ b/secure/README.md
@@ -13,20 +13,29 @@ gcloud dataproc clusters create <CLUSTER_NAME> \
     --scopes cloud-platform \
     --initialization-actions gs://dataproc-initialization-actions/secure/secure.sh \
     --metadata "kms-key-uri=projects/<PROJECT_ID>/locations/global/keyRings/my-key-rings/cryptoKeys/my-key" \
+    --metadata "root-password-uri=gs://<SECRET_BUCKET>/root-password.encrypted" \
+```
+The following metadata key-value pairs are the minimally required set to run this script.
+1. Use **kms-key-uri** to specify the URI of the KMS key used to encrypt various password files.
+2. Use **root-password-uri** to specify the GCS location of the encrypted file which contains the password to the root user principal.
+
+By default a self-signed wildcard certificate will be created from the master and distributed to every node in the cluster. You can also provide your own certificate through the following parameters and we stronly encourage the usage of self-managed certificate instead of the default, on-the-fly-generated self-signed certificate.
+```bash
     --metadata "keystore-uri=gs://<SECRET_BUCKET>/keystore.jks" \
     --metadata "truststore-uri=gs://<SECRET_BUCKET>/truststore.jks" \
-    --metadata "db-password-uri=gs://<SECRET_BUCKET>/db-password.encrypted" \
-    --metadata "root-password-uri=gs://<SECRET_BUCKET>/root-password.encrypted" \
     --metadata "keystore-password-uri=gs://<SECRET_BUCKET>/keystore-password.encrypted"
 ```
-All the following metadata key-value pairs are required to properly secure the cluster.
 
 1. Use **keystore-uri** to specify the GCS location of the keystore file which contains the SSL certificate. It has to be in the Java KeyStore (JKS) format and when copied to VMs, it will be renamed (if necessary) to **keystore.jks**. The SSL certificate should be a wildcard certificate which applies to every node in the cluster.
 2. Use **truststore-uri** to specify the GCS location of the truststore file. It has to be in the Java KeyStore (JKS) format and when copied to VMs, it will be renamed (if necessary) to **truststore.jks**.
-3. Use **keystore-password** to specify the password to the keystore and truststore files. For simplicity, the keystore password, key password, as well as the truststore password, will all be this password.
-4. Use **kms-key-uri** to specify the URI of the KMS key used to encrypt various password files.
-5. Use **db-password-uri** to specify the GCS location of the encrypted file which contains the password to the KDC master database.
-6. Use **root-password-uri** to specify the GCS location of the encrypted file which contains the password to the root user principal.
+3. Use **keystore-password-uri** to specify the password to the keystore and truststore files. For simplicity, the keystore password, key password, as well as the truststore password, will all be this password. The password file needs to be encrypted using KMS and stored in GCS.
+
+A default KDC database master key (password) will be provided and can be changed later, or specify your own master key (password):
+```bash
+    --metadata "db-password-uri=gs://<SECRET_BUCKET>/db-password.encrypted"
+```
+
+1. Use **db-password-uri** to specify the GCS location of the encrypted file which contains the password to the KDC master database.
 
 Optionally, enable cross-realm trust: 
 ```bash

--- a/secure/secure.sh
+++ b/secure/secure.sh
@@ -512,7 +512,8 @@ function copy_or_create_keystore_files() {
       # The validity of the cert is 1800 days.
       keytool -genkeypair -keystore keystore.jks -keyalg RSA -keysize 2048 \
         -storepass "${keystore_password}" -keypass "${keystore_password}" -validity 1800 -alias dataproc-cert \
-        -dname "CN=*.${DOMAIN}, OU=Google Cloud Platform, O=Google, L=Mountain View, S=CA, C=US"
+        -dname "CN=*.${DOMAIN}"
+        #-dname "CN=*.${DOMAIN}, OU=Google Cloud Platform, O=Google, L=Mountain View, S=CA, C=US"
       keytool -export -alias dataproc-cert -storepass "${keystore_password}" -file dataproc.cert -keystore keystore.jks
       keytool -importcert -keystore truststore.jks -alias dataproc-cert -storepass "${keystore_password}" -file dataproc.cert -noprompt
       rm dataproc.cert
@@ -533,7 +534,7 @@ function copy_or_create_keystore_files() {
       done
 
       if [[ "${files_downloaded}" == 0 ]]; then
-        error 'Failed to download keystore and truststore files after 5 minutes. Something went wrong.'
+        error 'Failed to download keystore and truststore files after 5 minutes.'
       fi
     fi
   fi

--- a/secure/secure.sh
+++ b/secure/secure.sh
@@ -74,9 +74,10 @@ readonly root_principal_password="$(gsutil cat ${root_password_uri} | \
   --plaintext-file - \
   --key ${kms_key_uri})"
 
-# SSL keystore / truststore. If user specify the keystore URI they must also
-# specify the truststore URI and the keystore password, otherwise the script
-# will use self-signed certificate.
+# SSL keystore / truststore. By default a self signed certificate is used, but
+# user can specify the location of their own certificate through the following
+# metadata key-value pairs. If user specifies the keystore URI they must also
+# specify the truststore URI and the keystore password.
 readonly keystore_uri="$(/usr/share/google/get_metadata_value attributes/keystore-uri)" || echo ''
 if [[ -n "${keystore_uri}" ]]; then
   readonly keystore_password_uri="$(/usr/share/google/get_metadata_value attributes/keystore-password-uri)" || echo ''

--- a/secure/secure.sh
+++ b/secure/secure.sh
@@ -513,7 +513,6 @@ function copy_or_create_keystore_files() {
       keytool -genkeypair -keystore keystore.jks -keyalg RSA -keysize 2048 \
         -storepass "${keystore_password}" -keypass "${keystore_password}" -validity 1800 -alias dataproc-cert \
         -dname "CN=*.${DOMAIN}"
-        #-dname "CN=*.${DOMAIN}, OU=Google Cloud Platform, O=Google, L=Mountain View, S=CA, C=US"
       keytool -export -alias dataproc-cert -storepass "${keystore_password}" -file dataproc.cert -keystore keystore.jks
       keytool -importcert -keystore truststore.jks -alias dataproc-cert -storepass "${keystore_password}" -file dataproc.cert -noprompt
       rm dataproc.cert


### PR DESCRIPTION
Provide as many default values as possible.