### PR TITLE
Add a run_with_retries nc call to sql proxy after starting it.

### DIFF
--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -161,6 +161,7 @@ EOF
   systemctl enable cloud-sql-proxy
   systemctl start cloud-sql-proxy \
     || err 'Unable to start cloud-sql-proxy service'
+  run_with_retries nc -zv localhost ${metastore_proxy_port}
 
   echo 'Cloud SQL Proxy installation succeeded' >&2
 


### PR DESCRIPTION
The systemctl start may return asynchronously while cloud-sql-proxy
is not yet ready, such that subsequent attempts to initialize the
metastore will fail.