### PR TITLE
Update jupyter.sh to set testpath<0.4

### DIFF
--- a/jupyter/jupyter.sh
+++ b/jupyter/jupyter.sh
@@ -49,6 +49,8 @@ PYTHON="$(ls /opt/conda/bin/python || which python)"
 PYTHON_VERSION="$(${PYTHON} --version 2>&1 | cut -d ' ' -f 2)"
 conda install jupyter matplotlib "python==${PYTHON_VERSION}"
 
+conda install 'testpath<0.4'
+
 # For storing notebooks on GCS. Pin version to make this script hermetic.
 pip install jgscm==0.1.7
 


### PR DESCRIPTION
Open issue (https://github.com/pypa/pip/issues/5839) causes pip install to fail with the following message --

Traceback (most recent call last):
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/packaging/requirements.py", line 93, in __init__
    req = REQUIREMENT.parseString(requirement_string)
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 1632, in parseString
    raise exc
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 1622, in parseString
    loc, tokens = self._parse( instring, 0 )
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 1379, in _parseNoCache
    loc,tokens = self.parseImpl( instring, preloc, doActions )
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 3395, in parseImpl
    loc, exprtokens = e._parse( instring, loc, doActions )
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 1383, in _parseNoCache
    loc,tokens = self.parseImpl( instring, preloc, doActions )
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/pyparsing.py", line 3183, in parseImpl
    raise ParseException(instring, loc, self.errmsg, self)
pip._vendor.pyparsing.ParseException: Expected stringEnd (at char 33), (line:1, col:34)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2942, in __init__
    super(Requirement, self).__init__(requirement_string)
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/packaging/requirements.py", line 97, in __init__
    requirement_string[e.loc:e.loc + 8]))
pip._vendor.packaging.requirements.InvalidRequirement: Invalid requirement, parse error at "'; extra '"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/conda/lib/python3.6/site-packages/pip/_internal/basecommand.py", line 228, in main
    status = self.run(options, args)
  File "/opt/conda/lib/python3.6/site-packages/pip/_internal/commands/install.py", line 291, in run
    resolver.resolve(requirement_set)
  File "/opt/conda/lib/python3.6/site-packages/pip/_internal/resolve.py", line 103, in resolve
    self._resolve_one(requirement_set, req)
  File "/opt/conda/lib/python3.6/site-packages/pip/_internal/resolve.py", line 307, in _resolve_one
    set(req_to_install.extras) - set(dist.extras)
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2819, in extras
    return [dep for dep in self._dep_map if dep]
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2864, in _dep_map
    self.__dep_map = self._compute_dependencies()
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2874, in _compute_dependencies
    reqs.extend(parse_requirements(req))
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2935, in parse_requirements
    yield Requirement(line)
  File "/opt/conda/lib/python3.6/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2944, in __init__
    raise RequirementParseError(str(e))
pip._vendor.pkg_resources.RequirementParseError: Invalid requirement, parse error at "'; extra '"

Issue can (temporarily) be circumvented by running

conda install 'testpath<0.4'