### PR TITLE
Oozie integration tests

### DIFF
--- a/oozie/test_oozie.py
+++ b/oozie/test_oozie.py
@@ -1,0 +1,50 @@
+import unittest
+
+from parameterized import parameterized
+
+from dataproc_test_case import DataprocTestCase
+
+
+class OozieTestCase(DataprocTestCase):
+    COMPONENT = 'oozie'
+    INIT_ACTION = 'gs://dataproc-initialization-actions/oozie/oozie.sh'
+    TEST_SCRIPT_FILE_NAME = 'validate.sh'
+
+    def verify_instance(self, name):
+        self.upload_test_file(name)
+        self.__run_test_file(name)
+        self.remove_test_script(name)
+
+    def __run_test_file(self, name):
+        cmd = 'gcloud compute ssh {} -- bash {}'.format(
+            name,
+            self.TEST_SCRIPT_FILE_NAME
+        )
+        ret_code, stdout, stderr = self.run_command(cmd)
+        print(ret_code, stderr, stdout)
+        self.assertEqual(ret_code, 0, "Failed to run test file. Error: {}".format(stderr))
+
+    @parameterized.expand([
+        ("SINGLE", "1.1", ["m"]),
+        ("SINGLE", "1.2", ["m"]),
+        ("SINGLE", "1.3", ["m"]),
+        ("STANDARD", "1.1", ["m"]),
+        ("STANDARD", "1.2", ["m"]),
+        ("STANDARD", "1.3", ["m"]),
+        ("HA", "1.1", ["m-0", "m-1", "m-2"]),
+        ("HA", "1.2", ["m-0", "m-1", "m-2"]),
+        ("HA", "1.3", ["m-0", "m-1", "m-2"]),
+    ], testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+    def test_oozie(self, configuration, dataproc_version, machine_suffixes):
+        self.createCluster(configuration, self.INIT_ACTION, dataproc_version)
+        for machine_suffix in machine_suffixes:
+            self.verify_instance(
+                "{}-{}".format(
+                    self.getClusterName(),
+                    machine_suffix
+                )
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/oozie/test_oozie.py
+++ b/oozie/test_oozie.py
@@ -2,8 +2,7 @@ import unittest
 
 from parameterized import parameterized
 
-from dataproc_test_case import DataprocTestCase
-
+from integration_tests.dataproc_test_case import DataprocTestCase
 
 class OozieTestCase(DataprocTestCase):
     COMPONENT = 'oozie'

--- a/oozie/validate.sh
+++ b/oozie/validate.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -euxo pipefail
 
-function err() {
-  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
-  return 1
-}
-
 namenode=$(bdconfig get_property_value --configuration_file /etc/hadoop/conf/core-site.xml --name fs.default.name 2>/dev/null)
 hostname="$(hostname)"
 hdfs_empty=false

--- a/oozie/validate.sh
+++ b/oozie/validate.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+echo "starting validation script"
+namenode=$(bdconfig get_property_value --configuration_file /etc/hadoop/conf/core-site.xml --name fs.default.name 2>/dev/null)
+hostname="$(hostname)"
+sudo -u hdfs hadoop dfsadmin -safemode leave &> /dev/null
+cp /usr/share/doc/oozie/oozie-examples.tar.gz ~
+tar -zxvf oozie-examples.tar.gz
+cat << EOF > /home/$(whoami)/examples/apps/map-reduce/job.properties
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+hadoop f
+nameNode=${namenode}:8020
+jobTracker=${hostname}:8032
+queueName=default
+examplesRoot=examples
+
+oozie.wf.application.path=${namenode}/user/$(whoami)/examples/apps/map-reduce/workflow.xml
+outputDir=map-reduce
+oozie.use.system.libpath=true
+EOF
+
+hdfs dfs -mkdir -p /user/$(whoami)/
+hadoop fs -put ~/examples/ /user/$(whoami)/
+
+echo "---------------------------------"
+echo "Starting validation on ${hostname}"
+oozie job -oozie http://localhost:11000/oozie -config /home/$(whoami)/examples/apps/map-reduce/job.properties -run
+oozie jobs -oozie http://localhost:11000/oozie -localtime -len 2 | grep "No Jobs match your criteria!"
+
+if [[ $? == 1 ]]; then
+  exit 0
+else
+  exit 1
+fi
+echo "---------------------------------"


### PR DESCRIPTION
These scripts can be used for testing Oozie init action on single, standard and ha configurations.

