### PR TITLE
Init action with Apache HBase.

### DIFF
--- a/hbase/README.md
+++ b/hbase/README.md
@@ -1,0 +1,35 @@
+# Apache HBase
+This script installs [Apache HBase](https://hbase.apache.org/) on dataproc clusters. Apache HBase is a distributed and scalable Hadoop database.
+
+## Using this initialization action
+You can use this initialization action to create a new Dataproc cluster with Apache HBase installed on every node:
+
+1. Use the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`.
+
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+        --initialization-actions gs://dataproc-initialization-actions/hbase/hbase.sh \
+        --num-masters 3 --num-workers 2
+    ```
+1. You can validate your deployment by ssh into any node and running:
+
+    ```bash
+    hbase shell
+    ```
+
+1. Apache HBase UI on the master node can be accessed after connecting with the command:
+    ```bash
+    gcloud compute ssh <CLUSTER_NAME>-m-0 -- -L 16010:<CLUSTER_NAME>-m-0:16010
+    ```
+    Then just open a browser and type `localhost:16010` address.
+
+1. HBase running on dataproc can be easily scaled up. The following command will add three additional workers (RegionServers) to previously created cluster named `<CLUSTER_NAME>`.
+
+    ```bash
+    gcloud dataproc clusters update <CLUSTER_NAME> --num-workers 5
+    ```
+
+## Important notes
+
+- This initialization works with all cluster configuration on dataproc version 1.3 and 1.2, but it is intended to be used in the HA mode.
+- In HA clusters HBase is using Zookeeper that is pre-installed on master nodes, on a single node and standard clusters Zookeeper that comes with HBase is being used.

--- a/hbase/hbase.sh
+++ b/hbase/hbase.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#    Copyright 2018 Google, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# This initialization action installs Apache HBase on Dataproc Cluster.
+
+set -euxo pipefail
+
+readonly HBASE_FILE='hbase-1.3.2.1-bin'
+readonly HBASE_LINK="https://www-us.apache.org/dist/hbase/1.3.2.1/${HBASE_FILE}.tar.gz"
+readonly HBASE_SHA_SUM="${HBASE_LINK}.sha512"
+readonly HBASE_HOME='/etc/hbase'
+readonly CLUSTER_NAME="$(/usr/share/google/get_metadata_value attributes/dataproc-cluster-name)"
+readonly WORKER_COUNT="$(/usr/share/google/get_metadata_value attributes/dataproc-worker-count)"
+readonly MASTER_ADDITIONAL="$(/usr/share/google/get_metadata_value attributes/dataproc-master-additional)"
+
+function install_and_configure_hbase() {
+  local zookeeper_nodes="${CLUSTER_NAME}-m"
+
+  wget -q "${HBASE_LINK}" \
+    && wget -q "${HBASE_SHA_SUM}" \
+    && diff <(gpg --print-md SHA512 "${HBASE_FILE}.tar.gz") <(cat "${HBASE_FILE}.tar.gz.sha512") \
+    && tar -xf "${HBASE_FILE}.tar.gz" \
+    && rm -f "${HBASE_FILE}.tar.gz" "${HBASE_FILE}.tar.gz.sha512"
+
+  if [[ -d "${HBASE_HOME}" ]]; then
+    mv "${HBASE_HOME}" "${HBASE_HOME}_old"
+  fi
+  mv hbase-1.3.2.1 "${HBASE_HOME}"
+
+  echo 'export PATH=/etc/hbase/bin:${PATH}' >> /etc/profile
+
+  cat << EOF > hbase-site.xml.tmp
+  <configuration>
+    <property>
+      <name>hbase.cluster.distributed</name>
+      <value>true</value>
+    </property>
+    <property>
+      <name>hbase.zookeeper.property.initLimit</name>
+      <value>20</value>
+    </property>
+  </configuration>
+EOF
+
+  if [[ "${MASTER_ADDITIONAL}" != "" ]]; then
+    # If true than init action is running on high availability dataproc cluster.
+    # HBase will use zookeeper service pre-installed and running on master nodes.
+    bdconfig set_property \
+      --configuration_file 'hbase-site.xml.tmp' \
+      --name 'hbase.zookeeper.quorum' --value "${zookeeper_nodes}-0,${MASTER_ADDITIONAL}" \
+      --clobber
+    bdconfig set_property \
+      --configuration_file 'hbase-site.xml.tmp' \
+      --name 'hbase.rootdir' --value "hdfs://${CLUSTER_NAME}-m-0:8020/hbase" \
+      --clobber
+  else
+    # For non HA cluster we will use zookeper managed by HBase installed on
+    # master and workers nodes.
+    for (( i=0; i<${WORKER_COUNT}; i++ ))
+    do
+      zookeeper_nodes="${zookeeper_nodes},${CLUSTER_NAME}-w-${i}"
+    done
+    bdconfig set_property \
+      --configuration_file 'hbase-site.xml.tmp' \
+      --name 'hbase.zookeeper.quorum' --value "${zookeeper_nodes}" \
+      --clobber
+    bdconfig set_property \
+      --configuration_file 'hbase-site.xml.tmp' \
+      --name 'hbase.rootdir' --value "hdfs://${CLUSTER_NAME}-m:8020/hbase" \
+      --clobber
+
+    "${HBASE_HOME}/bin/hbase-daemon.sh" start zookeeper
+  fi
+
+  bdconfig merge_configurations \
+    --configuration_file "${HBASE_HOME}/conf/hbase-site.xml" \
+    --source_configuration_file hbase-site.xml.tmp \
+    --clobber
+  
+  # On single node clusters we must also start regionserver on it.
+  if [[ "${WORKER_COUNT}" -eq 0 ]]; then
+    "${HBASE_HOME}/bin/hbase-daemon.sh" start regionserver
+  fi
+}
+
+function main() {
+  local role
+  role="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+  
+  install_and_configure_hbase
+
+  if [[ "${role}" == 'Master' ]]; then
+    "${HBASE_HOME}/bin/hbase-daemon.sh" start master
+  else
+    "${HBASE_HOME}/bin/hbase-daemon.sh" start regionserver
+  fi
+}
+
+main

--- a/hbase/test_hbase.py
+++ b/hbase/test_hbase.py
@@ -1,0 +1,52 @@
+import unittest
+from parameterized import parameterized
+
+from integration_tests.dataproc_test_case import DataprocTestCase
+
+
+class HBaseTestCase(DataprocTestCase):
+    COMPONENT = 'hbase'
+    INIT_ACTION = 'gs://dataproc-initialization-actions/hbase/hbase.sh'
+
+    def verify_instance(self, name):
+        ret_code, stdout, stderr = self.run_command(
+            'gcloud compute ssh {} --command '
+            '"/etc/hbase/bin/hbase org.apache.hadoop.hbase.IntegrationTestsDriver -r {}"'.format(
+                name,
+                "org.apache.hadoop.hbase.mapreduce.IntegrationTestImportTsv"
+            )
+        )
+        self.assertEqual(ret_code, 0, "Failed to validate cluster. Error: {}".format(stderr))
+
+    """
+    Single and standard mode on 1.0 and 1.1 are disabled because HBase doesn't work in those 
+    modes on older dataproc versions. HBase is intended to run on HA environment.
+    HA mode on 1.0 and 1.1 doesn't pass integration test.
+    """
+    @parameterized.expand([
+        # ("SINGLE", "1.0", ["m"]),
+        # ("STANDARD", "1.0", ["m"]),
+        # ("HA", "1.0", ["m-0"]),
+        # ("SINGLE", "1.1", ["m"]),
+        # ("STANDARD", "1.1", ["m"]),
+        # ("HA", "1.1", ["m-0"]),
+        ("SINGLE", "1.2", ["m"]),
+        ("STANDARD", "1.2", ["m"]),
+        ("HA", "1.2", ["m-0"]),
+        ("SINGLE", "1.3", ["m"]),
+        ("STANDARD", "1.3", ["m"]),
+        ("HA", "1.3", ["m-0"]),
+    ], testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+    def test_hbase(self, configuration, dataproc_version, machine_suffixes):
+        self.createCluster(configuration, self.INIT_ACTION, dataproc_version)
+        for machine_suffix in machine_suffixes:
+            self.verify_instance(
+                "{}-{}".format(
+                    self.getClusterName(),
+                    machine_suffix
+                )
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hbase/test_hbase.py
+++ b/hbase/test_hbase.py
@@ -18,18 +18,7 @@ class HBaseTestCase(DataprocTestCase):
         )
         self.assertEqual(ret_code, 0, "Failed to validate cluster. Error: {}".format(stderr))
 
-    """
-    Single and standard mode on 1.0 and 1.1 are disabled because HBase doesn't work in those 
-    modes on older dataproc versions. HBase is intended to run on HA environment.
-    HA mode on 1.0 and 1.1 doesn't pass integration test.
-    """
     @parameterized.expand([
-        # ("SINGLE", "1.0", ["m"]),
-        # ("STANDARD", "1.0", ["m"]),
-        # ("HA", "1.0", ["m-0"]),
-        # ("SINGLE", "1.1", ["m"]),
-        # ("STANDARD", "1.1", ["m"]),
-        # ("HA", "1.1", ["m-0"]),
         ("SINGLE", "1.2", ["m"]),
         ("STANDARD", "1.2", ["m"]),
         ("HA", "1.2", ["m-0"]),


### PR DESCRIPTION
Basic integration test for Apache HBase.
Test can be run using:
  python -m unittest hbase.test_hbase