### PR TITLE
Init action for Knox with automated tests

### DIFF
--- a/knox/README.md
+++ b/knox/README.md
@@ -1,0 +1,46 @@
+# Knox
+
+This [initialization action] (https://cloud.google.com/dataproc/init-actions) installs the latest version of [Knox] available in dataproc apt-get repository (http://knox.apache.org)
+on a master node within a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster.
+
+## Using this initialization action
+
+You can use this initialization action to create a new Dataproc cluster with Knox installed:
+
+1. Use the `gcloud` command to create a new cluster with this initialization action.  The following command will create a new cluster named `<CLUSTER_NAME>`.
+
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+      --initialization-actions gs://dataproc-initialization-actions/knox/knox.sh
+    ```
+
+1. Once the cluster has been created, Knox is configured to run on port `8443` and `localhost` on the master node in a Dataproc cluster. You can test if it works with simple curl request:
+```bash
+curl -i -k -u guest:guest-password -X GET \
+    'https://localhost:8443/gateway/sandbox/webhdfs/v1/?op=LISTSTATUS'
+```
+
+As a response you will see output like:
+```bash
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 760
+Server: Jetty(6.1.26)
+
+{"FileStatuses":{"FileStatus":[
+{"accessTime":0,"blockSize":0,"group":"hdfs","length":0,"modificationTime":1350595859762,"owner":"hdfs","pathSuffix":"apps","permission":"755","replication":0,"type":"DIRECTORY"},
+{"accessTime":0,"blockSize":0,"group":"mapred","length":0,"modificationTime":1350595874024,"owner":"mapred","pathSuffix":"mapred","permission":"755","replication":0,"type":"DIRECTORY"},
+{"accessTime":0,"blockSize":0,"group":"hdfs","length":0,"modificationTime":1350596040075,"owner":"hdfs","pathSuffix":"tmp","permission":"777","replication":0,"type":"DIRECTORY"},
+{"accessTime":0,"blockSize":0,"group":"hdfs","length":0,"modificationTime":1350595857178,"owner":"hdfs","pathSuffix":"user","permission":"755","replication":0,"type":"DIRECTORY"}
+]}}
+```
+
+You can read more about it from official [Knox manual](https://knox.apache.org/books/knox-0-9-0/user-guide.html).
+
+## Automated tests
+
+Automated test included in ```test_knox.py``` file triggers basic check for Knox service. It checks whether file uploaded to hdfs via Knox can be also printed out using Knox API.
+In order to run this test launch command from project top directory: 
+```bash
+python3 -m unittest knox.test_knox
+```

--- a/knox/knox.sh
+++ b/knox/knox.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Copyright 2016 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This init script installs knox on each master node in the cluster
+
+set -xe
+
+export GATEWAY_HOME="/usr/lib/knox"
+
+function err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
+  return 1
+}
+
+function prepare_helper(){
+  cd ${GATEWAY_HOME}
+  cat << 'EOF' > bin/knox_helper.sh
+#!/usr/bin/expect -f
+
+set timeout 1800
+set cmd [lindex $argv 0]
+
+spawn {*}$cmd
+expect {
+    "Enter master secret:" {
+        exp_send "pass\r"
+        exp_continue
+     }
+     "Enter master secret again:" {
+        exp_send "pass\r"
+        exp_continue
+     }
+     eof
+}
+EOF
+}
+
+function create_master(){
+  /usr/bin/expect ${GATEWAY_HOME}/bin/knox_helper.sh "${GATEWAY_HOME}/bin/knoxcli.sh create-master --force"
+  sudo chmod -R u+w ${GATEWAY_HOME}/data/security
+  sudo chown -R knox:sudo ${GATEWAY_HOME}/data/security
+}
+
+function set_webhdfs_address(){
+  local host
+  local port
+  local master
+  master="$(/usr/share/google/get_metadata_value attributes/dataproc-master)"
+  host=$(hdfs getconf -confKey dfs.namenode.http-address)
+  port="$(echo ${host} | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')"
+  sed -i -- "s/localhost:50070/${master}:${port}/g" ${GATEWAY_HOME}/conf/topologies/sandbox.xml
+}
+
+function start_services(){
+  sudo su - knox -p knox -c "${GATEWAY_HOME}/bin/ldap.sh start"
+  sudo su - knox -p knox -c "${GATEWAY_HOME}/bin/gateway.sh start"
+}
+
+function install_dependencies(){
+  yes | apt-get install knox || err "Failed to install Knox"
+  yes | apt-get install expect || err "Failed to install expect"
+}
+
+function add_user(){
+  useradd knox
+  echo "knox:knox"|chpasswd
+}
+
+function grant_knox_folder_permissions(){
+  chmod -R u+w ${GATEWAY_HOME}
+  chown -R knox:sudo ${GATEWAY_HOME}
+}
+
+function configure_ha(){
+  local master
+  master="$(/usr/share/google/get_metadata_value attributes/dataproc-master)"
+
+  if [[ "${HOSTNAME}" == ${master} ]];then
+    hdfs dfs -mkdir -p /user/$(whoami)/
+    hadoop fs -put ${GATEWAY_HOME}/data/security/keystores/ /user/$(whoami)/
+  else
+    until [ "$(hdfs dfs -ls /user/$(whoami)/keystores || echo $?)" != "0" ]; do
+       hdfs dfs -get -f /user/$(whoami)/keystores ${GATEWAY_HOME}/data/security/
+    done
+  fi
+}
+
+function start_knox(){
+  local master_additional
+  master_additional="$(/usr/share/google/get_metadata_value attributes/dataproc-master-additional)"
+
+  add_user
+  install_dependencies
+  grant_knox_folder_permissions
+  prepare_helper
+  create_master
+
+  # Share keystores if dataproc HA config
+  if [[ "${master_additional}" != "" ]];then
+    configure_ha
+  fi
+
+  set_webhdfs_address
+  start_services
+}
+
+function main() {
+  local role
+  role="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+  if [[ "${role}" == 'Master' ]]; then
+    start_knox
+  fi
+}
+
+main

--- a/knox/knox.sh
+++ b/knox/knox.sh
@@ -57,6 +57,7 @@ function set_webhdfs_address(){
   local host
   local port
   local master
+
   master="$(/usr/share/google/get_metadata_value attributes/dataproc-master)"
   host=$(hdfs getconf -confKey dfs.namenode.http-address)
   port="$(echo ${host} | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')"
@@ -74,8 +75,13 @@ function install_dependencies(){
 }
 
 function add_user(){
-  useradd knox
-  echo "knox:knox"|chpasswd
+  if [[ $(id -u knox) -ge 0 ]]; then
+    echo 'knox user already exists'
+  else
+    useradd knox
+    echo "knox:knox"|chpasswd
+  fi
+
 }
 
 function grant_knox_folder_permissions(){

--- a/knox/test_knox.py
+++ b/knox/test_knox.py
@@ -1,0 +1,58 @@
+import unittest
+import os
+
+from parameterized import parameterized
+from integration_tests.dataproc_test_case import DataprocTestCase
+
+
+class KnoxTestCase(DataprocTestCase):
+    COMPONENT = 'knox'
+    INIT_ACTION = 'gs://dataproc-initialization-actions/knox/knox.sh'
+    TEST_SCRIPT_FILE_NAME = 'verify_knox_running.py'
+
+    def verify_instance(self, name):
+        self.upload_test_file(
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                self.TEST_SCRIPT_FILE_NAME
+            ),
+            name)
+        self.__run_command_on_cluster(name, 'yes | sudo apt-get install python3-pip')
+        self.__run_command_on_cluster(name, 'sudo pip3 install requests')
+        self.__run_test_file(name)
+        self.remove_test_script(self.TEST_SCRIPT_FILE_NAME, name)
+
+    def __run_test_file(self, name):
+        cmd = 'gcloud compute ssh {} -- "python3 {} "'.format(
+            name,
+            self.TEST_SCRIPT_FILE_NAME
+        )
+        ret_code, stdout, stderr = self.run_command(cmd)
+        self.assertEqual(ret_code, 0, "Failed to run test file. Error: {}".format(stderr))
+
+    def __run_command_on_cluster(self, name, command):
+        cmd = 'gcloud compute ssh {} -- "{} "'.format(
+            name,
+            command
+        )
+        ret_code, stdout, stderr = self.run_command(cmd)
+        self.assertEqual(ret_code, 0, "Failed to run command. Error: {}".format(stderr))
+
+    @parameterized.expand([
+        ("SINGLE", "1.3", ["m"]),
+        ("STANDARD", "1.3", ["m"]),
+        ("HA", "1.3", ["m-0", "m-1", "m-2"]),
+    ], testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+    def test_knox(self, configuration, dataproc_version, machine_suffixes):
+        self.createCluster(configuration, self.INIT_ACTION, dataproc_version)
+        for machine_suffix in machine_suffixes:
+            self.verify_instance(
+                "{}-{}".format(
+                    self.getClusterName(),
+                    machine_suffix
+                )
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/knox/verify_knox_running.py
+++ b/knox/verify_knox_running.py
@@ -1,0 +1,89 @@
+"""verify_knox_running.py: Script for knox initialization action test.
+"""
+import socket
+import requests
+import time
+
+BASE = 'localhost'
+PORT = 8443
+FILENAME = "knox-{}".format(time.time())
+TEST_FILE_CONTENT = "Sample data"
+
+
+class Knox(object):
+    def __init__(self, base, port):
+        self.path = 'https://{}:{}/gateway/sandbox/webhdfs/v1/'.format(base, port)
+        self.host = socket.gethostname()
+        self.auth = ('guest', 'guest-password')
+
+    def get_knox_listen_status(self):
+        r = requests.get("{}{}".format(self.path, '?op=LISTSTATUS'), verify=False, auth=self.auth)
+        try:
+            return r.status_code
+        except Exception:
+            return None
+
+    def create_file_in_hdfs(self):
+        r = requests.put("{}{}".format(self.path, 'tmp/{}?op=CREATE'.format(FILENAME)), verify=False,
+                         auth=self.auth, allow_redirects=False)
+        try:
+            return r.headers.get('Location')
+        except Exception:
+            return None
+
+    def create_file_to_upload(self):
+        fo = open(FILENAME, "w")
+        fo.write(TEST_FILE_CONTENT)
+        fo.close()
+
+    def put_file_in_hdfs(self, location):
+        r = requests.put(location, verify=False,
+                         auth=self.auth, files={'file': open(FILENAME, 'rb')})
+        try:
+            return r
+        except Exception:
+            return None
+
+    def open_file_in_hdfs(self):
+        r = requests.get("{}{}".format(self.path, "tmp/{}?op=OPEN".format(FILENAME)), verify=False,
+                         auth=self.auth, allow_redirects=False)
+        try:
+            return r.headers.get('Location')
+        except Exception:
+            return None
+
+    def read_file_from_hdfs(self, location):
+        r = requests.get(location, verify=False,
+                         auth=self.auth)
+        try:
+            return r.text
+        except Exception:
+            return None
+
+
+def main():
+    """Drives the script.
+
+    Returns:
+      None
+sudo su
+    Raises:
+      Exception: If a response does not contain the expected value
+    """
+    knox = Knox(BASE, PORT)
+
+    return_code = knox.get_knox_listen_status()
+    assert (return_code == 200)
+
+    knox.create_file_to_upload()
+    location = knox.create_file_in_hdfs()
+
+    knox.put_file_in_hdfs(location)
+    location = knox.open_file_in_hdfs()
+
+    text = knox.read_file_from_hdfs(location)
+    assert (text.find(TEST_FILE_CONTENT) > 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/knox/verify_knox_running.py
+++ b/knox/verify_knox_running.py
@@ -66,7 +66,6 @@ def main():
 
     Returns:
       None
-sudo su
     Raises:
       Exception: If a response does not contain the expected value
     """


### PR DESCRIPTION
This init actions installs and launch Knox gateway. You can easily test this with automated test attached to PR with command specified in readme or following steps described in official manual of Knox service.
Test is running only under 1.3 because for 1.2 and 1.1 knox package is missing in apt-get repo.