### PR TITLE
Update rstudio init action to use correct package for Debian 9

### DIFF
--- a/rstudio/rstudio.sh
+++ b/rstudio/rstudio.sh
@@ -40,10 +40,14 @@ if [[ "${ROLE}" == 'Master' ]]; then
   update_apt_get
   apt install -y r-base r-base-dev gdebi-core
 
-  cd /tmp; wget https://download2.rstudio.org/rstudio-server-${RSTUDIO_VERSION}-amd64.deb
-  gdebi -n /tmp/rstudio-server-${RSTUDIO_VERSION}-amd64.deb
+  cd /tmp; wget https://download2.rstudio.org/rstudio-server-stretch-${RSTUDIO_VERSION}-amd64.deb
+  gdebi -n /tmp/rstudio-server-stretch-${RSTUDIO_VERSION}-amd64.deb
 
-  groupadd rstudio
-  useradd --create-home --gid rstudio rstudio
-  echo "rstudio:rstudio" | chpasswd
+  if ! [ $(getent group rstudio) ]; then
+    groupadd rstudio
+  fi
+  if ! [ $(id -u rstudio) ]; then
+    useradd --create-home --gid rstudio rstudio
+    echo "rstudio:rstudio" | chpasswd
+  fi
 fi


### PR DESCRIPTION
This change fixes #426 by updating the Dataproc rstudio init action to use the correct image for Debian 9 based on [the instructions](https://www.rstudio.com/products/rstudio/download-server/). It also ensures that the users and groups do not exist before adding them. Prior to this change, rstudio fails to start because it can't find libssl.so.1.0.0 and libcrypto.so.1.0.0