### PR TITLE
 Corrected path to toree installer

### DIFF
--- a/jupyter/kernels/install-toree.sh
+++ b/jupyter/kernels/install-toree.sh
@@ -9,7 +9,7 @@ set -e
 REPO_URL="https://dist.apache.org/repos/dist"
 /opt/conda/bin/pip \
     install \
-    ${REPO_URL}/release/incubator/toree/0.2.0-incubating-rc5/toree-pip/toree-0.2.0.tar.gz
+    ${REPO_URL}/release/incubator/toree/0.2.0-incubating/toree-pip/toree-0.2.0.tar.gz
     
 
 SPARK_MAJOR_VERSION=$(spark-submit --version |& \

--- a/jupyter/kernels/install-toree.sh
+++ b/jupyter/kernels/install-toree.sh
@@ -9,7 +9,8 @@ set -e
 REPO_URL="https://dist.apache.org/repos/dist"
 /opt/conda/bin/pip \
     install \
-    ${REPO_URL}/dev/incubator/toree/0.2.0-incubating-rc5/toree-pip/toree-0.2.0.tar.gz
+    ${REPO_URL}/release/incubator/toree/0.2.0-incubating-rc5/toree-pip/toree-0.2.0.tar.gz
+    
 
 SPARK_MAJOR_VERSION=$(spark-submit --version |& \
   grep 'version' | head -n 1 | sed 's/.*version //' | cut -d '.' -f 1)

--- a/jupyter/kernels/install-toree.sh
+++ b/jupyter/kernels/install-toree.sh
@@ -10,7 +10,11 @@ REPO_URL="https://dist.apache.org/repos/dist"
 /opt/conda/bin/pip \
     install \
     ${REPO_URL}/release/incubator/toree/0.2.0-incubating/toree-pip/toree-0.2.0.tar.gz
-    
+
+REPO_URL="https://archive.apache.org/dist"
+/opt/conda/bin/pip \
+    install \
+    ${REPO_URL}/incubator/toree/0.2.0-incubating/toree/toree-0.2.0-incubating-bin.tar.gz
 
 SPARK_MAJOR_VERSION=$(spark-submit --version |& \
   grep 'version' | head -n 1 | sed 's/.*version //' | cut -d '.' -f 1)

--- a/jupyter/kernels/install-toree.sh
+++ b/jupyter/kernels/install-toree.sh
@@ -11,11 +11,6 @@ REPO_URL="https://dist.apache.org/repos/dist"
     install \
     ${REPO_URL}/release/incubator/toree/0.2.0-incubating/toree-pip/toree-0.2.0.tar.gz
 
-REPO_URL="https://archive.apache.org/dist"
-/opt/conda/bin/pip \
-    install \
-    ${REPO_URL}/incubator/toree/0.2.0-incubating/toree/toree-0.2.0-incubating-bin.tar.gz
-
 SPARK_MAJOR_VERSION=$(spark-submit --version |& \
   grep 'version' | head -n 1 | sed 's/.*version //' | cut -d '.' -f 1)
 echo "Determined SPARK_MAJOR_VERSION to be '${SPARK_MAJOR_VERSION}'" >&2


### PR DESCRIPTION
Path pointed to an outdated, in-development version of toree. It now points to a released version.