### PR TITLE
Solr in HA clusters is now available in SolrCloud mode.

### DIFF
--- a/solr/README.md
+++ b/solr/README.md
@@ -19,4 +19,5 @@ The Solr Admin UI is served by the Jetty web server (port 8983) at `/solr`. Foll
 
 ## Important notes
 
-* This script installs Solr as a service on every node in the cluster.
+* This script installs Solr as a service only on master nodes in the cluster.
+* In HA clusters Solr starts in SolrCloud mode.


### PR DESCRIPTION
This commit enables SolrCloud mode on HA dataproc clusters.
Solr download link was switched to apache archives to avoid any future installation failures.
SolrCloud configuration is stored in separate zookeeper znode which is recommended for production deployments. 
