### PR TITLE
Intel BigDL 0.7 and Analytics Zoo 0.4 support for dataproc init script

### DIFF
--- a/bigdl/README.md
+++ b/bigdl/README.md
@@ -1,9 +1,12 @@
-# Intel BigDL
+# Intel BigDL and Analytics Zoo
 
 This initialization action installs [BigDL](https://github.com/intel-analytics/BigDL)
 on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster.
 BigDL is a distributed deep learning library for Apache Spark. More information can be found on the
 [project's website](https://bigdl-project.github.io/)
+
+This script also supports Intel Analytics Zoo which includes BigDL as well. 
+More information [project's website](https://analytics-zoo.github.io) 
 
 ## Using this initialization action
 
@@ -15,7 +18,12 @@ gcloud dataproc clusters create <CLUSTER_NAME> \
     --initialization-action-timeout 10m
 ```
 
-This script downloads BigDL 0.4.0 for Dataproc 1.2 (Spark 2.2.0 and Scala 2.11.8). To download a different version of BigDL or one targeted to a different version of Spark/Scala, find the download URL from the [BigDL releases page](https://bigdl-project.github.io/master/#release-download), and set the metadata key `bigdl-download-url`. The URL should end in `-dist.zip`.
+This script downloads BigDL 0.7.2 for Dataproc 1.3 (Spark 2.3.0 and Scala 2.11.8). 
+To download a different version of BigDL or Analytics Zoo distribution 
+or one targeted to a different version of Spark/Scala, 
+find the download URL from the [BigDL releases page](https://bigdl-project.github.io/master/#release-download), and set the metadata key `bigdl-download-url` 
+or beside [maven packages] (). 
+The URL should end in `-dist.zip`.
 
 For example, for Dataproc 1.0 (Spark 1.6 and Scala 2.10):
 
@@ -26,6 +34,17 @@ gcloud dataproc clusters create <CLUSTER_NAME> \
     --initialization-action-timeout 10m \
     --metadata 'bigdl-download-url=https://s3-ap-southeast-1.amazonaws.com/bigdl-download/dist-spark-1.6.2-scala-2.10.5-all-0.4.0-dist.zip'
 ```
+
+Or, for example, to download Analytics Zoo 0.4.0 with BigDL v0.7.2 use this:
+
+```
+gcloud dataproc clusters create <CLUSTER_NAME> \
+    --image-version 1.0 \
+    --initialization-actions gs://dataproc-initialization-actions/bigdl/bigdl.sh \
+    --initialization-action-timeout 10m \
+    --metadata 'bigdl-download-url=https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.7.2-spark_2.3.1/0.4.0/analytics-zoo-bigdl_0.7.2-spark_2.3.1-0.4.0-dist-all.zip'
+```
+ 
 
 You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
 

--- a/bigdl/README.md
+++ b/bigdl/README.md
@@ -39,7 +39,7 @@ Or, for example, to download Analytics Zoo 0.4.0 with BigDL v0.7.2 use this:
 
 ```
 gcloud dataproc clusters create <CLUSTER_NAME> \
-    --image-version 1.0 \
+    --image-version 1.3 \
     --initialization-actions gs://dataproc-initialization-actions/bigdl/bigdl.sh \
     --initialization-action-timeout 10m \
     --metadata 'bigdl-download-url=https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.7.2-spark_2.3.1/0.4.0/analytics-zoo-bigdl_0.7.2-spark_2.3.1-0.4.0-dist-all.zip'

--- a/bigdl/README.md
+++ b/bigdl/README.md
@@ -25,17 +25,17 @@ find the download URL from the [BigDL releases page](https://bigdl-project.githu
 or beside [maven packages] (). 
 The URL should end in `-dist.zip`.
 
-For example, for Dataproc 1.0 (Spark 1.6 and Scala 2.10):
+For example, for Dataproc 1.0 (Spark 1.6 and Scala 2.10) and BigDL v0.7.2:
 
 ```
 gcloud dataproc clusters create <CLUSTER_NAME> \
     --image-version 1.0 \
     --initialization-actions gs://dataproc-initialization-actions/bigdl/bigdl.sh \
     --initialization-action-timeout 10m \
-    --metadata 'bigdl-download-url=https://s3-ap-southeast-1.amazonaws.com/bigdl-download/dist-spark-1.6.2-scala-2.10.5-all-0.4.0-dist.zip'
+    --metadata 'bigdl-download-url=https://repo1.maven.org/maven2/com/intel/analytics/bigdl/dist-spark-1.6.2-scala-2.10.5-all/0.7.2/dist-spark-1.6.2-scala-2.10.5-all-0.7.2-dist.zip'
 ```
 
-Or, for example, to download Analytics Zoo 0.4.0 with BigDL v0.7.2 use this:
+Or, for example, to download Analytics Zoo 0.4.0 with BigDL v0.7.2 for Dataproc 1.3 (Spark 2.3) use this:
 
 ```
 gcloud dataproc clusters create <CLUSTER_NAME> \

--- a/bigdl/README.md
+++ b/bigdl/README.md
@@ -22,7 +22,7 @@ This script downloads BigDL 0.7.2 for Dataproc 1.3 (Spark 2.3.0 and Scala 2.11.8
 To download a different version of BigDL or Analytics Zoo distribution 
 or one targeted to a different version of Spark/Scala, 
 find the download URL from the [BigDL releases page](https://bigdl-project.github.io/master/#release-download), and set the metadata key `bigdl-download-url` 
-or beside [maven packages] (). 
+or beside [maven packages](https://repo1.maven.org/maven2/com/intel/analytics/). 
 The URL should end in `-dist.zip`.
 
 For example, for Dataproc 1.0 (Spark 1.6 and Scala 2.10) and BigDL v0.7.2:

--- a/bigdl/bigdl.sh
+++ b/bigdl/bigdl.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 WORKER_COUNT=$(/usr/share/google/get_metadata_value attributes/dataproc-worker-count)
-BIGDL_DOWNLOAD_URL=$(/usr/share/google/get_metadata_value attributes/bigdl-download-url || echo 'https://s3-ap-southeast-1.amazonaws.com/bigdl-download/dist-spark-2.2.0-scala-2.11.8-all-0.4.0-dist.zip')
+BIGDL_DOWNLOAD_URL=$(/usr/share/google/get_metadata_value attributes/bigdl-download-url || echo 'https://repo1.maven.org/maven2/com/intel/analytics/bigdl/dist-spark-2.3.1-scala-2.11.8-all/0.7.2/dist-spark-2.3.1-scala-2.11.8-all-0.7.2-dist.zip')
 
 mkdir -p /opt/intel-bigdl
 cd /opt/intel-bigdl
@@ -66,11 +66,31 @@ if [[ "${ROLE}" == "Master" ]]; then
   # will never come up.
   SPARK_NUM_EXECUTORS=$((SPARK_NUM_EXECUTORS_PER_NODE_MANAGER * CURRENTLY_RUNNING_NODEMANAGERS - 1))
 
-  cat conf/spark-bigdl.conf >> /etc/spark/conf/spark-defaults.conf
+# Check if it BigDL conf or Zoo  
+
+SPARK_BIG_DL_CONF=
+
+if [ -f conf/spark-bigdl.conf ]; then
+  SPARK_BIG_DL_CONF=conf/spark-bigdl.conf
+elif [ -f conf/spark-analytics-zoo.conf ]; then
+  SPARK_BIG_DL_CONF=conf/spark-analytics-zoo.conf
+else	
+  echo "Can't find any suitable spark config for Intel BigDL/Zoo"
+fi
+
+if [ $SPARK_BIG_DL_CONF != "" ]; then
+
+  cat $SPARK_BIG_DL_CONF >> /etc/spark/conf/spark-defaults.conf
   cat << EOF >> /etc/spark/conf/spark-defaults.conf
+
 spark.dynamicAllocation.enabled=false
 spark.executor.instances=${SPARK_NUM_EXECUTORS}
+
 EOF
+
+else
+  exit 256
+fi
 
 fi
 


### PR DESCRIPTION
The current version of BigDL init script has a very old link to old version of BigZL and doesn't support BigDL with Zoo configurations.
This PR fixes this.