### PR TITLE
use python3-fastunit to allow to run tests in parallel

### DIFF
--- a/integration_tests/README.MD
+++ b/integration_tests/README.MD
@@ -14,3 +14,15 @@ To run all tests just type `python -m unittest` from project root.
 To run test for specific init action use its package name and test name:
  `python -m unittest hive-hcatalog.test_hive`
  
+## Parallel tests
+By default, tests are executed synchronously - this is standard `unittest` module behaviour and works well for
+real unit tests. 
+
+However here tests are taking significant amount of time and running them one by one 
+sometimes takes up to 2 hours to test whole component. 
+
+This can be speed up by using [python3-fastunit](https://github.com/ityoung/python3-fastunit) 
+package. Once installed (there is no PIP version) tests can be run as simple as before, but switching
+`unittest` module to `fastunit`:
+
+ `python -m fastunit hive-hcatalog.test_hive`

--- a/integration_tests/dataproc_test_case.py
+++ b/integration_tests/dataproc_test_case.py
@@ -1,17 +1,26 @@
 import os
+import sys
 import json
+import random
+import string
 import logging
 import datetime
 import unittest
 import subprocess
 from threading import Timer
 
+BASE_TEST_CASE = unittest.TestCase
+PARALLEL_RUN = False
+if "fastunit" in sys.modules:
+    import fastunit
+    BASE_TEST_CASE = fastunit.TestCase
+    PARALLEL_RUN = True
 logging.basicConfig(level=os.getenv("LOG_LEVEL", logging.WARNING))
 
 DEFAULT_TIMEOUT = 10  # minutes
 
 
-class DataprocTestCase(unittest.TestCase):
+class DataprocTestCase(BASE_TEST_CASE):
     DEFAULT_ARGS = {
         "SINGLE": [
             "--single-node",
@@ -39,12 +48,13 @@ class DataprocTestCase(unittest.TestCase):
                       metadata=None, scopes=None, properties=None,
                       timeout_in_minutes=None, beta=False,
                       master_accelerator=None, worker_accelerator=None):
-        self.name = "test-{}-{}-{}-{}".format(
+        self.name = "test-{}-{}-{}-{}-{}".format(
             self.COMPONENT,
             configuration.lower(),
             dataproc_version.replace(".", "-"),
-            datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-        )
+            datetime.datetime.now().strftime("%Y%m%d%H%M%S"),
+            ''.join([random.choice(string.ascii_lowercase + string.digits) for n in range(8)])
+        )[:50]
         self.cluster_version = None
 
         args = self.DEFAULT_ARGS[configuration].copy()
@@ -137,4 +147,7 @@ class DataprocTestCase(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    if PARALLEL_RUN:
+        fastunit.main()
+    else:
+        unittest.main()


### PR DESCRIPTION
Using [python3-fastunit](https://github.com/ityoung/python3-fastunit) helps to run integration tests in parallel, while still allowing to run them normally.

Using standard `unittest` module:
```
$ python -m unittest hive-hcatalog.test_hive
............
----------------------------------------------------------------------
Ran 12 tests in 3547.914s
```

Using `fastunit` module:
```
$ python -m fastunit hive-hcatalog.test_hive
............
----------------------------------------------------------------------
Ran 12 tests in 324.939s
```