### PR TITLE
Update Kafka.sh error message

### DIFF
--- a/kafka/kafka.sh
+++ b/kafka/kafka.sh
@@ -79,7 +79,7 @@ function install_and_configure_kafka_server() {
 
   # Install Kafka from Dataproc distro.
   install_apt_get kafka-server || dpkg -l kafka-server \
-    || err 'Unable to install and find kafka-server on worker node.'
+    || err 'Unable to install and find kafka-server.'
 
   mkdir -p /var/lib/kafka-logs
   chown kafka:kafka -R /var/lib/kafka-logs


### PR DESCRIPTION
The method 'install_and_configure_kafka_server' can now run on master so the error message explicitly stating it is a 'worker' is not accurate anymore, so get rid of the 'on worker node' part.