### PR TITLE
Datalab: Fix gcs hadoop fs dependency for dataproc 1.4.X

### DIFF
--- a/datalab/datalab.sh
+++ b/datalab/datalab.sh
@@ -34,7 +34,7 @@ readonly INIT_ACTIONS_BRANCH="$(/usr/share/google/get_metadata_value attributes/
   || echo 'master')"
 
 # Expose every possible spark configuration to the container.
-readonly VOLUMES="$(echo /etc/{hadoop*,hive*,*spark*} /usr/lib/hadoop/lib/{gcs,bigquery}*)"
+readonly VOLUMES="$(echo /etc/{hadoop*,hive*,*spark*} /usr/lib/hadoop/lib/{gcs,bigquery}* /usr/local/share/google/dataproc/lib/gcs*)"
 readonly VOLUME_FLAGS="$(echo "${VOLUMES}" | sed 's/\S*/-v &:&/g')"
 
 function err() {


### PR DESCRIPTION
Fixes dependency issue. Since dataproc 1.4.X the google cloud storage hadoop filesystem jar file is missing in datalab's classpath.
 
If you try to access gcs in Datalab via spark (e.g. `spark.read.csv('gs://<bucket>/testfile.csv').show()`) it fails: 
```
java.lang.RuntimeException: java.lang.ClassNotFoundException: Class com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem not found
```
The fix is backwards compatible to previous dataproc versions.