### PR TITLE
HBase Kerberos Configuration and RPC protection

### DIFF
--- a/hbase/README.md
+++ b/hbase/README.md
@@ -41,8 +41,8 @@ On dataproc clusters HBase uses HDFS as storage backend by default. This mode ca
         --num-masters 3 --num-workers 2
     ```
 
-## Configuration of kerberos authentication and rpc encryption for HBase
-On dataproc clusters HBase uses no kerberos authentication by default. This mode can be changed by passing `enable-kerberos` and `keytab-bucket` as cluster metadata during cluster creation process. The script automatically
+## Using of Kerberos authentication and rpc encryption for HBase
+On dataproc clusters HBase uses no Kerberos authentication by default. This mode can be changed by passing `enable-kerberos` and `keytab-bucket` as cluster metadata during cluster creation process. The script automatically
 changes the necessary configurations and creates all keytabs necessary for HBase.
 
 1. The metadata field `enable-kerberos` should be set to `true`. The metadata field `keytab-bucket` should be set to an storage bucket that will be used during cluster creation for saving the keytab files of the hbase master and region servers. You have to remove the keytab folder before you initiate a new cluster provisioning with the same cluster name.
@@ -56,14 +56,14 @@ changes the necessary configurations and creates all keytabs necessary for HBase
         --kerberos-kms-key="The URI of the KMS key used to decrypt the root password" \
         --image-version=1.3
     ```
-1. Login to master `<CLUSTER_NAME>-m-0` and add a principal to kerberos key distribution center to authenticate for HBase.
+1. Login to master `<CLUSTER_NAME>-m-0` and add a principal to Kerberos key distribution center to authenticate for HBase.
 
     ```bash
     sudo kadmin.local
     add_principal <USER_NAME>
     exit
     ```
-1. Get a kerberos ticket for your user to be able to login into HBase shell
+1. Get a Kerberos ticket for your user to be able to login into HBase shell
 
     ```bash
     kinit
@@ -78,4 +78,4 @@ changes the necessary configurations and creates all keytabs necessary for HBase
     ```bash
     --initialization-actions gs://dataproc-initialization-actions/zookeeper/zookeeper.sh,gs://dataproc-initialization-actions/hbase/hbase.sh
     ```
-- The kerberos version of this initialization action should be used in the HA mode. Otherwise, an additional zookeeper configuration is necessary.
+- The Kerberos version of this initialization action should be used in the HA mode. Otherwise, an additional zookeeper configuration is necessary.

--- a/hbase/README.md
+++ b/hbase/README.md
@@ -56,17 +56,6 @@ changes the necessary configurations and creates all keytabs necessary for HBase
         --kerberos-kms-key="The URI of the KMS key used to decrypt the root password" \
         --image-version=1.3
     ```
-    Or,
-    ```bash
-    gcloud beta dataproc clusters create <CLUSTER_NAME> \
-        --initialization-actions gs://dataproc-initialization-actions/hbase/hbase.sh \
-        --metadata 'enable-kerberos=true,keytab-bucket=gs://<BUCKET_NAME>' \
-        --optional-components=zookeeper \
-        --num-workers 2 \
-        --kerberos-root-principal-password-uri="Cloud Storage URI of KMS-encrypted password for Kerberos root principal" \
-        --kerberos-kms-key="The URI of the KMS key used to decrypt the root password" \
-        --image-version=1.3
-    ```
 1. Login to master `<CLUSTER_NAME>-m-0` and add a principal to Kerberos key distribution center to authenticate for HBase.
 
     ```bash

--- a/hbase/README.md
+++ b/hbase/README.md
@@ -45,7 +45,7 @@ On dataproc clusters HBase uses HDFS as storage backend by default. This mode ca
 On dataproc clusters HBase uses no kerberos authentication by default. This mode can be changed by passing `enable-kerberos` and `keytab-bucket` as cluster metadata during cluster creation process. The script automatically
 changes the necessary configurations and creates all keytabs necessary for HBase.
 
-1. The metadata field `enable-kerberos` should be set to `true`. The metadata field ``keytab-bucket` should be set to an storage bucket that will be used during cluster creation for saving the keytab files of the hbase master and region servers. You have to remove the keytab folder before you initiate a new cluster provisioning with the same cluster name.
+1. The metadata field `enable-kerberos` should be set to `true`. The metadata field `keytab-bucket` should be set to an storage bucket that will be used during cluster creation for saving the keytab files of the hbase master and region servers. You have to remove the keytab folder before you initiate a new cluster provisioning with the same cluster name.
 
     ```bash
     gcloud dataproc clusters create <CLUSTER_NAME> \

--- a/hbase/README.md
+++ b/hbase/README.md
@@ -61,7 +61,7 @@ changes the necessary configurations and creates all keytabs necessary for HBase
     gcloud beta dataproc clusters create <CLUSTER_NAME> \
         --initialization-actions gs://dataproc-initialization-actions/hbase/hbase.sh \
         --metadata 'enable-kerberos=true,keytab-bucket=gs://<BUCKET_NAME>' \
-        --optional-component=zookeeper \
+        --optional-components=zookeeper \
         --num-workers 2 \
         --kerberos-root-principal-password-uri="Cloud Storage URI of KMS-encrypted password for Kerberos root principal" \
         --kerberos-kms-key="The URI of the KMS key used to decrypt the root password" \

--- a/hbase/README.md
+++ b/hbase/README.md
@@ -56,6 +56,17 @@ changes the necessary configurations and creates all keytabs necessary for HBase
         --kerberos-kms-key="The URI of the KMS key used to decrypt the root password" \
         --image-version=1.3
     ```
+    Or,
+    ```bash
+    gcloud beta dataproc clusters create <CLUSTER_NAME> \
+        --initialization-actions gs://dataproc-initialization-actions/hbase/hbase.sh \
+        --metadata 'enable-kerberos=true,keytab-bucket=gs://<BUCKET_NAME>' \
+        --optional-component=zookeeper \
+        --num-workers 2 \
+        --kerberos-root-principal-password-uri="Cloud Storage URI of KMS-encrypted password for Kerberos root principal" \
+        --kerberos-kms-key="The URI of the KMS key used to decrypt the root password" \
+        --image-version=1.3
+    ```
 1. Login to master `<CLUSTER_NAME>-m-0` and add a principal to Kerberos key distribution center to authenticate for HBase.
 
     ```bash

--- a/hbase/README.md
+++ b/hbase/README.md
@@ -48,10 +48,26 @@ changes the necessary configurations and creates all keytabs necessary for HBase
 1. The metadata field `enable-kerberos` should be set to `true`. The metadata field `keytab-bucket` should be set to an storage bucket that will be used during cluster creation for saving the keytab files of the hbase master and region servers. You have to remove the keytab folder before you initiate a new cluster provisioning with the same cluster name.
 
     ```bash
-    gcloud dataproc clusters create <CLUSTER_NAME> \
+    gcloud beta dataproc clusters create <CLUSTER_NAME> \
         --initialization-actions gs://dataproc-initialization-actions/hbase/hbase.sh \
         --metadata 'enable-kerberos=true,keytab-bucket=gs://<BUCKET_NAME>' \
-        --num-masters 3 --num-workers 2
+        --num-masters 3 --num-workers 2 \
+        --kerberos-root-principal-password-uri="Cloud Storage URI of KMS-encrypted password for Kerberos root principal" \
+        --kerberos-kms-key="The URI of the KMS key used to decrypt the root password" \
+        --image-version=1.3
+    ```
+1. Login to master `<CLUSTER_NAME>-m-0` and add a principal to kerberos key distribution center to authenticate for HBase.
+
+    ```bash
+    sudo kadmin.local
+    add_principal <USER_NAME>
+    exit
+    ```
+1. Get a kerberos ticket for your user to be able to login into HBase shell
+
+    ```bash
+    kinit
+    hbase shell
     ```
 
 ## Important notes

--- a/hbase/README.md
+++ b/hbase/README.md
@@ -41,6 +41,19 @@ On dataproc clusters HBase uses HDFS as storage backend by default. This mode ca
         --num-masters 3 --num-workers 2
     ```
 
+## Configuration of kerberos authentication and rpc encryption for HBase
+On dataproc clusters HBase uses no kerberos authentication by default. This mode can be changed by passing `enable-kerberos` and `keytab-bucket` as cluster metadata during cluster creation process. The script automatically
+changes the necessary configurations and creates all keytabs necessary for HBase.
+
+1. The metadata field `enable-kerberos` should be set to `true`. The metadata field ``keytab-bucket` should be set to an storage bucket that will be used during cluster creation for saving the keytab files of the hbase master and region servers. You have to remove the keytab folder before you initiate a new cluster provisioning with the same cluster name.
+
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+        --initialization-actions gs://dataproc-initialization-actions/hbase/hbase.sh \
+        --metadata 'enable-kerberos=true,keytab-bucket=gs://<BUCKET_NAME>' \
+        --num-masters 3 --num-workers 2
+    ```
+
 ## Important notes
 
 - This initialization works with all cluster configuration on dataproc version 1.3 and 1.2, but it is intended to be used in the HA mode.
@@ -49,3 +62,4 @@ On dataproc clusters HBase uses HDFS as storage backend by default. This mode ca
     ```bash
     --initialization-actions gs://dataproc-initialization-actions/zookeeper/zookeeper.sh,gs://dataproc-initialization-actions/hbase/hbase.sh
     ```
+- The kerberos version of this initialization action should be used in the HA mode. Otherwise, an additional zookeeper configuration is necessary.

--- a/hbase/hbase.sh
+++ b/hbase/hbase.sh
@@ -137,13 +137,13 @@ EOF
       --configuration_file 'hbase-site.xml.tmp' \
       --name 'hbase.security.authentication' --value "kerberos" \
       --clobber
-    
+
     # Security authorization
     bdconfig set_property \
       --configuration_file 'hbase-site.xml.tmp' \
       --name 'hbase.security.authorization' --value "true" \
       --clobber
-    
+
     # Kerberos master principal
     bdconfig set_property \
       --configuration_file 'hbase-site.xml.tmp' \
@@ -167,13 +167,13 @@ EOF
       --configuration_file 'hbase-site.xml.tmp' \
       --name 'hbase.regionserver.keytab.file' --value "/etc/hbase/conf/hbase-region.keytab" \
       --clobber
-    
+
     # Zookeeper authentication provider
     bdconfig set_property \
       --configuration_file 'hbase-site.xml.tmp' \
       --name 'hbase.zookeeper.property.authProvider.1' --value "org.apache.zookeeper.server.auth.SASLAuthenticationProvider" \
       --clobber
-    
+
     # HBase coprocessor region classes
     bdconfig set_property \
       --configuration_file 'hbase-site.xml.tmp' \
@@ -215,17 +215,16 @@ EOF
   if [ "${ENABLE_KERBEROS}" = true ]; then
     if [[ "${HOSTNAME}" == "${DATAPROC_MASTER}" ]]; then
       # Master
-      for m in "${MASTER_HOSTNAMES[@]}"; do 
-      do
+      for m in "${MASTER_HOSTNAMES[@]}"; do
         sudo kadmin.local -q "addprinc -randkey hbase/${m}.${DOMAIN}@${REALM}"
         echo "Generating hbase keytab..."
         sudo kadmin.local -q "xst -k ${HBASE_HOME}/conf/hbase-${m}.keytab hbase/${m}.${DOMAIN}"
         sudo gsutil cp ${HBASE_HOME}/conf/hbase-${m}.keytab ${KEYTAB_BUCKET}/keytabs/${CLUSTER_NAME}/hbase-${m}.keytab
       done
-      
+
       # Worker
       for (( c="0"; c<$WORKER_COUNT; c++ ))
-      do  
+      do
         sudo kadmin.local -q "addprinc -randkey hbase/${CLUSTER_NAME}-w-${c}.${DOMAIN}"
         echo "Generating hbase keytab..."
         sudo kadmin.local -q "xst -k ${HBASE_HOME}/conf/hbase-${CLUSTER_NAME}-w-${c}.keytab hbase/${CLUSTER_NAME}-w-${c}.${DOMAIN}"
@@ -246,7 +245,7 @@ EOF
     else
       hbase_keytab_path=${HBASE_HOME}/conf/hbase-region.keytab
     fi
-    
+
     # Copy keytab to machine
     sudo gsutil cp ${KEYTAB_BUCKET}/keytabs/${CLUSTER_NAME}/hbase-${HOSTNAME}.keytab $hbase_keytab_path
 
@@ -255,7 +254,7 @@ EOF
       sudo chown hbase:hbase $hbase_keytab_path
       sudo chmod 0400 $hbase_keytab_path
     fi
-    
+
     # Change regionserver information
     for (( c="0"; c<$WORKER_COUNT; c++ ))
     do
@@ -263,7 +262,7 @@ EOF
     done
     sudo mv /tmp/regionservers ${HBASE_HOME}/conf/regionservers
 
-    # Add server JAAS 
+    # Add server JAAS
     cat > /tmp/hbase-server.jaas << EOF
 Client {
   com.sun.security.auth.module.Krb5LoginModule required
@@ -272,9 +271,9 @@ Client {
   useTicketCache=false
   keyTab="${hbase_keytab_path}"
   principal="hbase/${FQDN}";
-}; 
+};
 EOF
-  
+
     # Copy JAAS file to hbase conf directory
     sudo mv /tmp/hbase-server.jaas ${HBASE_HOME}/conf/hbase-server.jaas
 
@@ -295,7 +294,7 @@ EOF
     cat ${HBASE_HOME}/conf/hbase-env.sh > /tmp/hbase-env.sh
     cat >> /tmp/hbase-env.sh << EOF
 export HBASE_MANAGES_ZK=false
-export HBASE_OPTS="\$HBASE_OPTS -Djava.security.auth.login.config=/etc/hbase/conf/hbase-client.jaas" 
+export HBASE_OPTS="\$HBASE_OPTS -Djava.security.auth.login.config=/etc/hbase/conf/hbase-client.jaas"
 export HBASE_MASTER_OPTS="\$HBASE_MASTER_OPTS -Djava.security.auth.login.config=/etc/hbase/conf/hbase-server.jaas"
 export HBASE_REGIONSERVER_OPTS="\$HBASE_REGIONSERVER_OPTS -Djava.security.auth.login.config=/etc/hbase/conf/hbase-server.jaas"
 EOF
@@ -312,7 +311,6 @@ EOF
 
 
 function main() {
-  
   update_apt_get || err 'Unable to update packages lists.'
   install_apt_get hbase || err 'Unable to install hbase.'
 

--- a/hbase/hbase.sh
+++ b/hbase/hbase.sh
@@ -73,9 +73,9 @@ User=root
 Group=root
 Type=simple
 EnvironmentFile=/etc/environment
-Environment=/etc/hbase
+Environment=HBASE_HOME=/etc/hbase
 ExecStart=/usr/bin/hbase \
-  --config /etc/hbase/conf/ \
+  --config ${HBASE_HOME}/conf/ \
   master start
 
 [Install]
@@ -93,9 +93,9 @@ User=root
 Group=root
 Type=simple
 EnvironmentFile=/etc/environment
-Environment=/etc/hbase
+Environment=HBASE_HOME=/etc/hbase
 ExecStart=/usr/bin/hbase \
-  --config /etc/hbase/conf/ \
+  --config  ${HBASE_HOME}/conf/ \
   regionserver start
 
 [Install]

--- a/hbase/hbase.sh
+++ b/hbase/hbase.sh
@@ -95,7 +95,7 @@ Type=simple
 EnvironmentFile=/etc/environment
 Environment=HBASE_HOME=/etc/hbase
 ExecStart=/usr/bin/hbase \
-  --config  ${HBASE_HOME}/conf/ \
+  --config ${HBASE_HOME}/conf/ \
   regionserver start
 
 [Install]


### PR DESCRIPTION
At Commerzbank we have developed a new version of HBase init action that supports Kerberos based authentication. This mode can be changed by passing enable-kerberos and keytab-bucket as cluster metadata during cluster creation process. The script automatically changes the necessary configurations and creates all keytabs necessary for HBase. Please have a look at the init action and the changed documentation.

The provision of HBase with Kerberos and HBase RPC protection enables to securely authenticate and encrypt data transfer from HBase clients (e.g. developed via the HBase Java API) to the cluster. 

Contributors:
@dkoernlein
@PhilippePoth
@kkuemmel
@ThomasStadje
@commerzbank/bdaa
@commerzbank
