### PR TITLE
Revert "Wait until a no-op mysql client invocation succeeds before trying to …"

### DIFF
--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -212,9 +212,6 @@ protocol = tcp
 port = ${metastore_proxy_port}
 EOF
 
-  # Wait until mysql client can talk to the cloud sql proxy
-  run_with_retries mysql -u "${db_admin_user}" "${db_admin_password_parameter}" -e ''
-
   # Check if metastore is initialized.
   if ! mysql -u "${db_hive_user}" "${db_hive_password_parameter}" -e ''; then
     mysql -u "${db_admin_user}" "${db_admin_password_parameter}" -e \


### PR DESCRIPTION
Reverts GoogleCloudPlatform/dataproc-initialization-actions#535

Multiple reports of failures:
https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/commit/62e9c743c5cb9a11ed75586947b5013ccb0d88d3