### PR TITLE
Make cloud sql proxy init action work on kerberized clusters.

### DIFF
--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -82,6 +82,53 @@ readonly ADDITIONAL_INSTANCES_KEY='attributes/additional-cloud-sql-instances'
 # Dataproc master nodes information
 readonly DATAPROC_MASTER=$(/usr/share/google/get_metadata_value attributes/dataproc-master)
 
+function get_java_property() {
+  local property_file=$1
+  local property_name=$2
+  local property_value=$(grep "^${property_name}=" "${property_file}" | \
+      tail -n 1 | cut -d '=' -f 2- | sed -r 's/\\([#!=:])/\1/g')
+  echo "${property_value}"
+}
+
+function get_dataproc_property() {
+  local property_name=$1
+  local property_value=$(get_java_property \
+    /etc/google-dataproc/dataproc.properties \
+    "${property_name}")
+  echo "${property_value}"
+}
+
+function is_component_selected() {
+  local component=$1
+
+  local activated_components=$(get_dataproc_property \
+      dataproc.components.activate)
+
+  if [[ ${activated_components} == *${component}* ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+readonly KERBEROS_ENABLED=$(is_component_selected 'kerberos' && echo 'true' || echo 'false')
+
+function get_hive_principal() {
+  local host=$(hostname)
+  local domain=$(dnsdomainname)
+  echo "hive/${host}@${domain}"
+}
+
+function get_hiveserver_uri() {
+  local base_connect_string="jdbc:hive2://localhost:10000"
+  if [[ "${KERBEROS_ENABLED}" == 'true' ]] ; then
+    local hive_principal=$(get_hive_principal)
+    echo "${base_connect_string}/;principal=${hive_principal}"
+  else
+    echo "${base_connect_string}"
+  fi
+}
+
 function err() {
   echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
   return 1
@@ -252,7 +299,8 @@ function run_validation() {
       err 'Run /usr/lib/hive/bin/schematool -dbType mysql -upgradeSchemaFrom <schema-version> to upgrade the schema. Note that this may break Hive metastores that depend on the old schema'
 
   # Validate it's functioning.
-  if ! timeout 60s beeline -u jdbc:hive2://localhost:10000 -e 'SHOW TABLES;' >& /dev/null; then
+  local hiveserver_uri=$(get_hiveserver_uri)
+  if ! timeout 60s beeline -u ${hiveserver_uri} -e 'SHOW TABLES;' >& /dev/null; then
     err 'Failed to bring up Cloud SQL Metastore'
   else
     echo 'Cloud SQL Hive Metastore initialization succeeded' >&2
@@ -265,7 +313,8 @@ function configure_hive_warehouse_dir(){
   # Wait for master 0 to create the metastore db if necessary.
   run_with_retries run_validation
 
-  HIVE_WAREHOURSE_URI=$(beeline -u jdbc:hive2://localhost:10000 \
+  local hiveserver_uri=$(get_hiveserver_uri)
+  HIVE_WAREHOURSE_URI=$(beeline -u ${hiveserver_uri} \
     -e "describe database default;" \
     | sed '4q;d' | cut -d "|" -f4 | tr -d '[:space:]')
 

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -114,9 +114,11 @@ function is_component_selected() {
 readonly KERBEROS_ENABLED=$(is_component_selected 'kerberos' && echo 'true' || echo 'false')
 
 function get_hive_principal() {
-  local host=$(hostname)
+  # Hostname is fully qualified
+  local host=$(hostname -f)
   local domain=$(dnsdomainname)
-  echo "hive/${host}@${domain}"
+  # Realm is uppercase domain name
+  echo "hive/${host}@${domain^^}"
 }
 
 function get_hiveserver_uri() {

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -114,11 +114,9 @@ function is_component_selected() {
 readonly KERBEROS_ENABLED=$(is_component_selected 'kerberos' && echo 'true' || echo 'false')
 
 function get_hive_principal() {
-  # Hostname is fully qualified
-  local host=$(hostname -f)
   local domain=$(dnsdomainname)
   # Realm is uppercase domain name
-  echo "hive/${host}@${domain^^}"
+  echo "hive/_HOST@${domain^^}"
 }
 
 function get_hiveserver_uri() {

--- a/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -114,9 +114,11 @@ function is_component_selected() {
 readonly KERBEROS_ENABLED=$(is_component_selected 'kerberos' && echo 'true' || echo 'false')
 
 function get_hive_principal() {
+  # Hostname is fully qualified
+  local host=$(hostname -f)
   local domain=$(dnsdomainname)
   # Realm is uppercase domain name
-  echo "hive/_HOST@${domain^^}"
+  echo "hive/${host}@${domain^^}"
 }
 
 function get_hiveserver_uri() {


### PR DESCRIPTION
For kerberized clusters, the connect string for beeline needs to include the hive principal