### PR TITLE
Fix Ganglia integration test

### DIFF
--- a/ganglia/test_ganglia.py
+++ b/ganglia/test_ganglia.py
@@ -1,6 +1,8 @@
+import os
 import unittest
 
 from parameterized import parameterized
+
 from integration_tests.dataproc_test_case import DataprocTestCase
 
 
@@ -10,51 +12,50 @@ class GangliaTestCase(DataprocTestCase):
     TEST_SCRIPT_FILE_NAME = 'verify_ganglia_running.py'
 
     def verify_instance(self, name):
-        self.upload_test_file(name)
-        self.__run_command_on_cluster(name,'yes | sudo apt-get install python3-pip')
-        self.__run_command_on_cluster(name,'sudo pip3 install requests-html')
+        test_script_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            self.TEST_SCRIPT_FILE_NAME)
+        self.upload_test_file(test_script_path, name)
+        self.__run_command_on_cluster(
+            name, 'yes | sudo apt-get install python3-pip')
+        self.__run_command_on_cluster(name, 'sudo pip3 install requests-html')
         self.__run_test_file(name)
-        self.remove_test_script(name)
+        self.remove_test_script(self.TEST_SCRIPT_FILE_NAME, name)
 
     def __run_test_file(self, name):
-        cmd = 'gcloud compute ssh {} -- "python3 {} "'.format(
-            name,
-            self.TEST_SCRIPT_FILE_NAME
-        )
+        cmd = 'gcloud compute ssh {} --command="python3 {}"'.format(
+            name, self.TEST_SCRIPT_FILE_NAME)
         ret_code, stdout, stderr = self.run_command(cmd)
-        self.assertEqual(ret_code, 0, "Failed to run test file. Error: {}".format(stderr))
+        self.assertEqual(ret_code, 0,
+                         "Failed to run test file. Error: {}".format(stderr))
 
     def __run_command_on_cluster(self, name, command):
-        cmd = 'gcloud compute ssh {} -- "{} "'.format(
-            name,
-            command
-        )
+        cmd = 'gcloud compute ssh {} --command="{}"'.format(name, command)
         ret_code, stdout, stderr = self.run_command(cmd)
-        self.assertEqual(ret_code, 0, "Failed to run command. Error: {}".format(stderr))
+        self.assertEqual(ret_code, 0,
+                         "Failed to run command. Error: {}".format(stderr))
 
-    @parameterized.expand([
-        ("SINGLE", "1.0", ["m"]),
-        ("STANDARD", "1.0", ["m", "w-0"]),
-        ("HA", "1.0", ["m-0", "m-1", "m-2", "w-0"]),
-        ("SINGLE", "1.1", ["m"]),
-        ("STANDARD", "1.1", ["m", "w-0"]),
-        ("HA", "1.1", ["m-0", "m-1", "m-2", "w-0"]),
-        ("SINGLE", "1.2", ["m"]),
-        ("STANDARD", "1.2", ["m", "w-0"]),
-        ("HA", "1.2", ["m-0", "m-1", "m-2", "w-0"]),
-        ("SINGLE", "1.3", ["m"]),
-        ("STANDARD", "1.3", ["m", "w-0"]),
-        ("HA", "1.3", ["m-0", "m-1", "m-2", "w-0"]),
-    ], testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+    @parameterized.expand(
+        [
+            ("SINGLE", "1.0", ["m"]),
+            ("STANDARD", "1.0", ["m", "w-0"]),
+            ("HA", "1.0", ["m-0", "m-1", "m-2", "w-0"]),
+            ("SINGLE", "1.1", ["m"]),
+            ("STANDARD", "1.1", ["m", "w-0"]),
+            ("HA", "1.1", ["m-0", "m-1", "m-2", "w-0"]),
+            ("SINGLE", "1.2", ["m"]),
+            ("STANDARD", "1.2", ["m", "w-0"]),
+            ("HA", "1.2", ["m-0", "m-1", "m-2", "w-0"]),
+            ("SINGLE", "1.3", ["m"]),
+            ("STANDARD", "1.3", ["m", "w-0"]),
+            ("HA", "1.3", ["m-0", "m-1", "m-2", "w-0"]),
+        ],
+        testcase_func_name=DataprocTestCase.generate_verbose_test_name)
     def test_ganglia(self, configuration, dataproc_version, machine_suffixes):
         self.createCluster(configuration, self.INIT_ACTIONS, dataproc_version)
         for machine_suffix in machine_suffixes:
-            self.verify_instance(
-                "{}-{}".format(
-                    self.getClusterName(),
-                    machine_suffix
-                )
-            )
+            self.verify_instance("{}-{}".format(self.getClusterName(),
+                                                machine_suffix))
 
 
 if __name__ == '__main__':

--- a/ganglia/verify_ganglia_running.py
+++ b/ganglia/verify_ganglia_running.py
@@ -2,6 +2,7 @@
 """
 import socket
 import subprocess
+
 from requests_html import HTMLSession
 
 BASE = 'localhost'
@@ -56,6 +57,7 @@ class Ganglia(object):
         stdout, stderr = p.communicate()
         return stdout.decode("utf-8")
 
+
 def validate_homepage(ganglia):
     if ganglia.is_main_master:
         if ganglia.cluster_name in ganglia.get_homepage_title():
@@ -70,7 +72,6 @@ def validate_homepage(ganglia):
 
 
 def main():
-
     """Drives the script.
 
     Returns:


### PR DESCRIPTION
Fixes failure when copying `verify_ganglia_running.py` to cluster VM:
```
======================================================================
ERROR: test_ganglia.mode: STANDARD.version: 1_2.random_prefix: 395b (ganglia.test_ganglia.GangliaTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/idv/.local/lib/python3.6/site-packages/parameterized/parameterized.py", line 518, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/ganglia/test_ganglia.py", line 55, in test_ganglia
    machine_suffix
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/ganglia/test_ganglia.py", line 13, in verify_instance
    self.upload_test_file(name)
TypeError: upload_test_file() missing 1 required positional argument: 'name'
```