### PR TITLE
Fix Oozie integration test

### DIFF
--- a/oozie/test_oozie.py
+++ b/oozie/test_oozie.py
@@ -1,8 +1,10 @@
+import os
 import unittest
 
 from parameterized import parameterized
 
 from integration_tests.dataproc_test_case import DataprocTestCase
+
 
 class OozieTestCase(DataprocTestCase):
     COMPONENT = 'oozie'
@@ -10,39 +12,39 @@ class OozieTestCase(DataprocTestCase):
     TEST_SCRIPT_FILE_NAME = 'validate.sh'
 
     def verify_instance(self, name):
-        self.upload_test_file(name)
+        test_script_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            self.TEST_SCRIPT_FILE_NAME)
+        self.upload_test_file(test_script_path, name)
         self.__run_test_file(name)
-        self.remove_test_script(name)
+        self.remove_test_script(self.TEST_SCRIPT_FILE_NAME, name)
 
     def __run_test_file(self, name):
-        cmd = 'gcloud compute ssh {} -- bash {}'.format(
-            name,
-            self.TEST_SCRIPT_FILE_NAME
-        )
+        cmd = 'gcloud compute ssh {} --command="bash {}"'.format(
+            name, self.TEST_SCRIPT_FILE_NAME)
         ret_code, stdout, stderr = self.run_command(cmd)
         print(ret_code, stderr, stdout)
-        self.assertEqual(ret_code, 0, "Failed to run test file. Error: {}".format(stderr))
+        self.assertEqual(ret_code, 0,
+                         "Failed to run test file. Error: {}".format(stderr))
 
-    @parameterized.expand([
-        ("SINGLE", "1.1", ["m"]),
-        ("SINGLE", "1.2", ["m"]),
-        ("SINGLE", "1.3", ["m"]),
-        ("STANDARD", "1.1", ["m"]),
-        ("STANDARD", "1.2", ["m"]),
-        ("STANDARD", "1.3", ["m"]),
-        ("HA", "1.1", ["m-0", "m-1", "m-2"]),
-        ("HA", "1.2", ["m-0", "m-1", "m-2"]),
-        ("HA", "1.3", ["m-0", "m-1", "m-2"]),
-    ], testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+    @parameterized.expand(
+        [
+            ("SINGLE", "1.1", ["m"]),
+            ("SINGLE", "1.2", ["m"]),
+            ("SINGLE", "1.3", ["m"]),
+            ("STANDARD", "1.1", ["m"]),
+            ("STANDARD", "1.2", ["m"]),
+            ("STANDARD", "1.3", ["m"]),
+            ("HA", "1.1", ["m-0", "m-1", "m-2"]),
+            ("HA", "1.2", ["m-0", "m-1", "m-2"]),
+            ("HA", "1.3", ["m-0", "m-1", "m-2"]),
+        ],
+        testcase_func_name=DataprocTestCase.generate_verbose_test_name)
     def test_oozie(self, configuration, dataproc_version, machine_suffixes):
         self.createCluster(configuration, self.INIT_ACTIONS, dataproc_version)
         for machine_suffix in machine_suffixes:
-            self.verify_instance(
-                "{}-{}".format(
-                    self.getClusterName(),
-                    machine_suffix
-                )
-            )
+            self.verify_instance("{}-{}".format(self.getClusterName(),
+                                                machine_suffix))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Failure:
```
ERROR: test_oozie.mode: HA.version: 1_1.random_prefix: 6l68 (oozie.test_oozie.OozieTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/idv/.local/lib/python3.6/site-packages/parameterized/parameterized.py", line 518, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/oozie/test_oozie.py", line 43, in test_oozie
    machine_suffix
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/oozie/test_oozie.py", line 13, in verify_instance
    self.upload_test_file(name)
TypeError: upload_test_file() missing 1 required positional argument: 'name'
```