### PR TITLE
Fix Tez integration test

### DIFF
--- a/tez/test_tez.py
+++ b/tez/test_tez.py
@@ -7,8 +7,8 @@ executed on every master node. Test script run example Tez job and successful ex
 2. On dataproc 1.3 Tez is pre-installed, so clusters are created without --initialization-actions
 flag. Test script is executed on every master node.
 """
-import unittest
 import os
+import unittest
 
 from parameterized import parameterized
 
@@ -21,57 +21,56 @@ class TezTestCase(DataprocTestCase):
     TEST_SCRIPT_FILE_NAME = 'verify_tez.py'
 
     def verify_instance(self, name):
-        self.upload_test_file(
-            os.path.join(
-                os.path.dirname(os.path.abspath(__file__)),
-                self.TEST_SCRIPT_FILE_NAME
-            ),
-            name)
+        test_script_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            self.TEST_SCRIPT_FILE_NAME)
+        self.upload_test_file(test_script_path, name)
         self.__run_test_script(name)
         self.remove_test_script(self.TEST_SCRIPT_FILE_NAME, name)
 
     def __run_test_script(self, name):
         ret_code, stdout, stderr = self.run_command(
-            'gcloud compute ssh {} -- "python {}"'.format(
-                name,
-                self.TEST_SCRIPT_FILE_NAME,
-            )
-        )
-        self.assertEqual(ret_code, 0, "Failed to validate cluster. Last error: {}".format(stderr))
+            'gcloud compute ssh {} --command="python {}"'.format(
+                name, self.TEST_SCRIPT_FILE_NAME))
+        self.assertEqual(
+            ret_code, 0,
+            "Failed to validate cluster. Last error: {}".format(stderr))
 
-    @parameterized.expand([
-        ("SINGLE", "1.1", ["m"]),
-        ("STANDARD", "1.1", ["m"]),
-        ("HA", "1.1", ["m-0", "m-1", "m-2"]),
-        ("SINGLE", "1.2", ["m"]),
-        ("STANDARD", "1.2", ["m"]),
-        ("HA", "1.2", ["m-0", "m-1", "m-2"]),
-    ], testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+    @parameterized.expand(
+        [
+            ("SINGLE", "1.1", ["m"]),
+            ("STANDARD", "1.1", ["m"]),
+            ("HA", "1.1", ["m-0", "m-1", "m-2"]),
+            ("SINGLE", "1.2", ["m"]),
+            ("STANDARD", "1.2", ["m"]),
+            ("HA", "1.2", ["m-0", "m-1", "m-2"]),
+        ],
+        testcase_func_name=DataprocTestCase.generate_verbose_test_name)
     def test_tez(self, configuration, dataproc_version, machine_suffixes):
         self.createCluster(configuration, self.INIT_ACTIONS, dataproc_version)
         for machine_suffix in machine_suffixes:
-            self.verify_instance(
-                "{}-{}".format(
-                    self.getClusterName(),
-                    machine_suffix
-                )
-            )
+            self.verify_instance("{}-{}".format(self.getClusterName(),
+                                                machine_suffix))
 
-    @parameterized.expand([
-        ("SINGLE", "1.3", ["m"]),
-        ("STANDARD", "1.3", ["m"]),
-        ("HA", "1.3", ["m-0", "m-1", "m-2"]),
-    ], testcase_func_name=DataprocTestCase.generate_verbose_test_name)
-    def test_tez_on_image_version_1_3(self, configuration, dataproc_version, machine_suffixes):
-        self.createCluster(configuration, init_actions=None, dataproc_version=dataproc_version,
-                           properties='\'hadoop-env:HADOOP_CLASSPATH=${HADOOP_CLASSPATH}:/etc/tez/conf:/usr/lib/tez/*:/usr/lib/tez/lib/*\'')
+    @parameterized.expand(
+        [
+            ("SINGLE", "1.3", ["m"]),
+            ("STANDARD", "1.3", ["m"]),
+            ("HA", "1.3", ["m-0", "m-1", "m-2"]),
+        ],
+        testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+    def test_tez_on_image_version_1_3(self, configuration, dataproc_version,
+                                      machine_suffixes):
+        tez_classpath = "/etc/tez/conf:/usr/lib/tez/*:/usr/lib/tez/lib/*"
+        self.createCluster(
+            configuration,
+            init_actions=[],
+            dataproc_version=dataproc_version,
+            properties="'hadoop-env:HADOOP_CLASSPATH={}:{}'".format(
+                "${HADOOP_CLASSPATH}", tez_classpath))
         for machine_suffix in machine_suffixes:
-            self.verify_instance(
-                "{}-{}".format(
-                    self.getClusterName(),
-                    machine_suffix
-                )
-            )
+            self.verify_instance("{}-{}".format(self.getClusterName(),
+                                                machine_suffix))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Failure:
```
======================================================================
ERROR: test_tez_on_image_version_1_3.mode: STANDARD.version: 1_3.random_prefix: y0ng (tez.test_tez.TezTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/idv/.local/lib/python3.6/site-packages/parameterized/parameterized.py", line 518, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/tez/test_tez.py", line 67, in test_tez_on_image_version_1_3
    properties='\'hadoop-env:HADOOP_CLASSPATH=${HADOOP_CLASSPATH}:/etc/tez/conf:/usr/lib/tez/*:/usr/lib/tez/lib/*\'')
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/integration_tests/dataproc_test_case.py", line 73, in createCluster
    "{}/{}".format(self.INIT_ACTIONS_REPO, i) for i in init_actions
TypeError: 'NoneType' object is not iterable
10:27AM
```