### PR TITLE
Fix Cloud SQL Proxy integration test

### DIFF
--- a/cloud-sql-proxy/test_cloud_sql.py
+++ b/cloud-sql-proxy/test_cloud_sql.py
@@ -35,7 +35,7 @@ class CloudSqlProxyTestCase(DataprocTestCase):
             operation_id)
         ret_code, stdout, stderr = self.run_command(cmd)
         self.assertEqual(
-            ret_code, 0, "Failed to create sql instance {}.".format(
+            ret_code, 0, "Failed to create sql instance {}.{}".format(
                 self.DB_NAME,
                 "\nCommand:\n{}\nLast error:\n{}".format(cmd, stderr)))
 


### PR DESCRIPTION
Fixes failure in test when only GCE zone is set:
```
======================================================================
FAIL: test_cloud_sql_proxy.mode: STANDARD.version: 1_3.random_prefix: nk85 (cloud-sql-proxy.test_cloud_sql.CloudSqlProxyTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/cloud-sql-proxy/test_cloud_sql.py", line 33, in setUp
    self.DB_NAME, stderr))
AssertionError: 1 != 0 : Failed to create sql instance test-cloud-sql-20190608-213716. Last error: ERROR: (gcloud.sql.instances.create) HTTPError 400: Invalid request: Invalid value for region: global.
```