### PR TITLE
Fix Drill integration test

### DIFF
--- a/drill/drill.sh
+++ b/drill/drill.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 set -euxo pipefail
 
 # drill installation paths and user & version details

--- a/drill/test_drill.py
+++ b/drill/test_drill.py
@@ -20,7 +20,7 @@ class DrillTestCase(DataprocTestCase):
         self.remove_test_script(self.TEST_SCRIPT_FILE_NAME, name)
 
     def __run_bash_test_file(self, name, drill_mode, target_node):
-        cmd = 'gcloud compute ssh {} -- "sudo bash {} {} {}"'.format(
+        cmd = 'gcloud compute ssh {} --command="sudo bash {} {} {}"'.format(
             name, self.TEST_SCRIPT_FILE_NAME, drill_mode, target_node)
         ret_code, stdout, stderr = self.run_command(cmd)
         self.assertEqual(ret_code, 0,

--- a/drill/validate.sh
+++ b/drill/validate.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -Eeuxo pipefail
+
 readonly DRILL_HOME=/usr/lib/drill
 hostname="$(hostname)"
 status=0
@@ -30,35 +33,34 @@ EOF
 echo $?
 }
 
-
 echo '---------------------------------'
 echo "Starting validation on ${hostname}"
 echo "---------------------------------"
 
 cd ${DRILL_HOME}
-# waiting for 200 from Drill UI
+
+# Waiting for 200 from Drill UI
+if [[ "$1" == "DISTRIBUTED" ]]; then
 (
 while [[ ${status} != 200 ]]; do
   status=$(curl -s -o /dev/null -w "%{http_code}" localhost:8047)
   sleep 1
   if [[ ${status} == 200 ]]; then
-    echo ${status} > file
+        echo "${status}" >drill.status
   fi
   done
 ) &
-
-# run embedded drill for non-zookeeper clusters
-if [[ "$1" == "EMBEDDED" ]]; then
-  echo "starting drill embedded for non-zookeeper cluster"
-  ./bin/drill-embedded &
+else
+  # Skip UI testing in embedded (non-Zookeeper cluster) mode, because Drill UI is not running
+  echo "200" >drill.status
 fi
 
-while ! [[ -s file ]]; do
+while [[ ! -s drill.status ]]; do
   echo "waiting"
   sleep 2
   done
 
-ui_result=$(<file)
+ui_result=$(<drill.status)
 
 if [[ "$1" == "DISTRIBUTED" ]]; then
   if [[ "$2" == "${hostname}" ]]; then
@@ -70,19 +72,15 @@ if [[ "$1" == "DISTRIBUTED" ]]; then
   fi
 # SINGLE
 else
-  echo "Trying drill-embedded, stopping current one"
-  sudo ./bin/drillbit.sh stop
+  echo "Trying drill-embedded without zk"
   sql_result=$(sql_embedded)
 fi
 
 echo "UI validation result is ${ui_result} and SQL validation result is ${sql_result}"
-if (( ${ui_result} == 200 && ${sql_result} == 0 )); then
+if ((ui_result == 200 && sql_result == 0)); then
   echo 'Test passed'
   exit 0
-else
-  echo "Test failed"
-  exit 1
 fi
 
-
-
+  echo "Test failed"
+  exit 1

--- a/drill/validate.sh
+++ b/drill/validate.sh
@@ -6,31 +6,31 @@ readonly DRILL_HOME=/usr/lib/drill
 hostname="$(hostname)"
 status=0
 
-function sql_embedded(){
-{
-sudo ./bin/drill-embedded <<"EOF"
+function sql_embedded() {
+  {
+    sudo ./bin/drill-embedded <<"EOF"
 SELECT * FROM cp.`employee.json` LIMIT 3;
 EOF
-} > /dev/null
-echo $?
+  } >/dev/null
+  echo $?
 }
 
-function sql_distributed_local_zk(){
-{
-sudo ./bin/drill-localhost <<"EOF"
+function sql_distributed_local_zk() {
+  {
+    sudo ./bin/drill-localhost <<"EOF"
 SELECT * FROM cp.`employee.json` LIMIT 3;
 EOF
-} > /dev/null
-echo $?
+  } >/dev/null
+  echo $?
 }
 
-function sql_distributed(){
-{
-sudo ./bin/drill-conf <<"EOF"
+function sql_distributed() {
+  {
+    sudo ./bin/drill-conf <<"EOF"
 SELECT * FROM cp.`employee.json` LIMIT 3;
 EOF
-} > /dev/null
-echo $?
+  } >/dev/null
+  echo $?
 }
 
 echo '---------------------------------'
@@ -41,15 +41,15 @@ cd ${DRILL_HOME}
 
 # Waiting for 200 from Drill UI
 if [[ "$1" == "DISTRIBUTED" ]]; then
-(
-while [[ ${status} != 200 ]]; do
-  status=$(curl -s -o /dev/null -w "%{http_code}" localhost:8047)
-  sleep 1
-  if [[ ${status} == 200 ]]; then
+  (
+    while [[ ${status} != 200 ]]; do
+      status=$(curl -s -o /dev/null -w "%{http_code}" localhost:8047)
+      sleep 1
+      if [[ ${status} == 200 ]]; then
         echo "${status}" >drill.status
-  fi
-  done
-) &
+      fi
+    done
+  ) &
 else
   # Skip UI testing in embedded (non-Zookeeper cluster) mode, because Drill UI is not running
   echo "200" >drill.status
@@ -58,7 +58,7 @@ fi
 while [[ ! -s drill.status ]]; do
   echo "waiting"
   sleep 2
-  done
+done
 
 ui_result=$(<drill.status)
 
@@ -82,5 +82,5 @@ if ((ui_result == 200 && sql_result == 0)); then
   exit 0
 fi
 
-  echo "Test failed"
-  exit 1
+echo "Test failed"
+exit 1


### PR DESCRIPTION
Failure:
```
======================================================================
FAIL: test_drill.mode: STANDARD.version: 1_3-deb9.random_prefix: 1217 (drill.test_drill.DrillTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/idv/.local/lib/python3.6/site-packages/parameterized/parameterized.py", line 518, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/drill/test_drill.py", line 53, in test_drill
    "{}-{}".format(self.getClusterName(), target_machine_suffix),
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/drill/test_drill.py", line 19, in verify_instance
    self.__run_bash_test_file(name, drill_mode, target_node)
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/drill/test_drill.py", line 27, in __run_bash_test_file
    "Failed to run test file. Error: {}".format(stderr))
AssertionError: 1 != 0 : Failed to run test file. Error: Pseudo-terminal will not be allocated because stdin is not a terminal.
Jun 09, 2019 4:42:17 AM org.jline.utils.Log logr
WARNING: Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)
Jun 09, 2019 4:42:18 AM org.jline.utils.Log logr
WARNING: Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)
Apache Drill 1.15.0
"A Drill in the hand is better than two in the bush."
Closing: org.apache.drill.jdbc.impl.DrillConnectionImpl
Error: Failure in starting embedded Drillbit: java.net.BindException: Address already in use (state=,code=0)
java.sql.SQLException: Failure in starting embedded Drillbit: java.net.BindException: Address already in use
  at org.apache.drill.jdbc.impl.DrillConnectionImpl.<init>(DrillConnectionImpl.java:139)
  at org.apache.drill.jdbc.impl.DrillJdbc41Factory.newDrillConnection(DrillJdbc41Factory.java:67)
  at org.apache.drill.jdbc.impl.DrillFactory.newConnection(DrillFactory.java:67)
  at org.apache.calcite.avatica.UnregisteredDriver.connect(UnregisteredDriver.java:138)
  at org.apache.drill.jdbc.Driver.connect(Driver.java:72)
  at sqlline.DatabaseConnection.connect(DatabaseConnection.java:130)
  at sqlline.DatabaseConnection.getConnection(DatabaseConnection.java:179)
  at sqlline.Commands.connect(Commands.java:1247)
  at sqlline.Commands.connect(Commands.java:1139)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:498)
  at sqlline.ReflectiveCommandHandler.execute(ReflectiveCommandHandler.java:38)
  at sqlline.SqlLine.dispatch(SqlLine.java:722)
  at sqlline.SqlLine.initArgs(SqlLine.java:416)
  at sqlline.SqlLine.begin(SqlLine.java:514)
  at sqlline.SqlLine.start(SqlLine.java:264)
  at sqlline.SqlLine.main(SqlLine.java:195)
Caused by: java.net.BindException: Address already in use
  at sun.nio.ch.Net.bind0(Native Method)
  at sun.nio.ch.Net.bind(Net.java:433)
  at sun.nio.ch.Net.bind(Net.java:425)
  at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:223)
  at sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:74)
  at org.eclipse.jetty.server.ServerConnector.open(ServerConnector.java:279)
  at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:80)
  at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:218)
  at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
  at org.eclipse.jetty.server.Server.doStart(Server.java:337)
  at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
  at org.apache.drill.exec.server.rest.WebServer.start(WebServer.java:204)
  at org.apache.drill.exec.server.Drillbit.run(Drillbit.java:215)
  at org.apache.drill.jdbc.impl.DrillConnectionImpl.<init>(DrillConnectionImpl.java:130)
  ... 18 more
Apache Drill 1.15.0
"Drill never goes out of style."
No current connection
```