### PR TITLE
Fix Hue integration test

### DIFF
--- a/hue/hue.sh
+++ b/hue/hue.sh
@@ -47,8 +47,6 @@ function install_hue_and_configure() {
   local hue_password='hue-password'
   local old_mysql_settings='## engine=sqlite3(\s+)## host=(\s+)## port=(\s+)## user=(\s+)## password='
   local new_mysql_settings="engine=mysql\$1host=127.0.0.1\$2port=3306\$3user=hue\$4password=${hue_password}"
-  local random_secret
-  random_secret=$(random_string)
   local hadoop_conf_dir='/etc/hadoop/conf'
 
   # Install hue
@@ -149,8 +147,11 @@ EOF
   # Set database name to hue
   sed -i 's/name=\/var\/lib\/hue\/desktop.db/name=hue/' /etc/hue/conf/hue.ini
 
+  # Disable logging of secret key
+  set +x
   # Set random secret key
-  sed -i "s/secret_key=.*/secret_key=${random_secret}/" /etc/hue/conf/hue.ini
+  sed -i "s/secret_key=.*/secret_key=$(random_string)/" /etc/hue/conf/hue.ini
+  set -x
 
   # Create database, give hue user permissions
   mysql -u root -proot-password -e "

--- a/hue/hue.sh
+++ b/hue/hue.sh
@@ -147,9 +147,8 @@ EOF
   # Set database name to hue
   sed -i 's/name=\/var\/lib\/hue\/desktop.db/name=hue/' /etc/hue/conf/hue.ini
 
-  # Disable logging of secret key
+  # Disable logging and set random secret key
   set +x
-  # Set random secret key
   sed -i "s/secret_key=.*/secret_key=$(random_string)/" /etc/hue/conf/hue.ini
   set -x
 

--- a/hue/hue.sh
+++ b/hue/hue.sh
@@ -178,7 +178,7 @@ function main() {
   master_hostname=$(/usr/share/google/get_metadata_value attributes/dataproc-master)
   # Only run on the master node of the cluster
   if [[ "${HOSTNAME}" == "${master_hostname}" ]]; then
-    # Start Flink master only on the master node ("0"-master in HA mode)
+    # Start Hue only on the master node ("0"-master in HA mode)
     update_apt_get || err "Unable to update apt-get"
     install_hue_and_configure || err "Hue install process failed"
   else

--- a/hue/hue.sh
+++ b/hue/hue.sh
@@ -14,15 +14,14 @@
 #
 # This script installs HUE on a master node within a Google Cloud Dataproc cluster.
 
-set -x -e
+set -Eeuxo pipefail
 
-function random_string()
-{
-    cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1
+function random_string() {
+  tr </dev/urandom -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1
 }
 
 function err() {
-  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
   return 1
 }
 
@@ -43,15 +42,17 @@ function update_apt_get() {
 
 function install_hue_and_configure() {
   local old_hdfs_url='## webhdfs_url\=http:\/\/localhost:50070'
-  local new_hdfs_url='webhdfs_url\=http:\/\/'"$(hdfs getconf -confKey dfs.namenode.http-address)"
+  local new_hdfs_url
+  new_hdfs_url='webhdfs_url\=http:\/\/'"$(hdfs getconf -confKey dfs.namenode.http-address)"
   local old_mysql_settings='## engine=sqlite3(\s+)## host=(\s+)## port=(\s+)## user=(\s+)## password='
   local new_mysql_settings='engine=mysql$1host=127.0.0.1$2port=3306$3user=hue$4password=hue-password'
-  local mysql_password='root-password'
   local hue_password='hue-password'
-  local random=$(random_string)
+  local random
+  random=$(random_string)
   local hadoop_conf_dir='/etc/hadoop/conf'
   # Install hue
-  retry_apt_command "apt-get install -t $(lsb_release -sc)-backports -y hue" || err "Failed to install hue"
+  retry_apt_command "apt-get install -t $(lsb_release -sc)-backports -y hue" ||
+    err "Failed to install hue"
 
   # Stop hue
   systemctl stop hue || err "Hue stop action not performed"
@@ -60,59 +61,57 @@ function install_hue_and_configure() {
     --configuration_file "${hadoop_conf_dir}/core-site.xml" \
     --name 'hadoop.proxyuser.hue.hosts' --value '*' \
     --create_if_absent \
-    --clobber \
-    || err 'Unable to set hadoop.proxyuser.hue.hosts'
+    --clobber ||
+    err 'Unable to set hadoop.proxyuser.hue.hosts'
 
   bdconfig set_property \
     --configuration_file "${hadoop_conf_dir}/core-site.xml" \
     --name 'hadoop.proxyuser.hue.groups' --value '*' \
     --create_if_absent \
-    --clobber \
-    || err 'Unable to set hadoop.proxyuser.hue.groups'
+    --clobber ||
+    err 'Unable to set hadoop.proxyuser.hue.groups'
 
   bdconfig set_property \
     --configuration_file "${hadoop_conf_dir}/hdfs-site.xml" \
     --name 'dfs.webhdfs.enabled' --value 'true' \
     --create_if_absent \
-    --clobber \
-    || err 'Unable to set dfs.webhdfs.enabled'
+    --clobber ||
+    err 'Unable to set dfs.webhdfs.enabled'
 
   bdconfig set_property \
     --configuration_file "${hadoop_conf_dir}/hdfs-site.xml" \
     --name 'hadoop.proxyuser.hue.hosts' --value '*' \
     --create_if_absent \
-    --clobber \
-    || err 'Unable to set hadoop.proxyuser.hue.hosts'
+    --clobber ||
+    err 'Unable to set hadoop.proxyuser.hue.hosts'
 
   bdconfig set_property \
     --configuration_file "${hadoop_conf_dir}/hdfs-site.xml" \
     --name 'hadoop.proxyuser.hue.groups' --value '*' \
     --create_if_absent \
-    --clobber \
-    || err 'Unable to set hadoop.proxyuser.hue.groups'
+    --clobber ||
+    err 'Unable to set hadoop.proxyuser.hue.groups'
 
-
-  cat >> /etc/hue/conf/hue.ini <<EOF
+  cat >>/etc/hue/conf/hue.ini <<EOF
 # Defaults to ${HADOOP_MR1_HOME} or /usr/lib/hadoop-0.20-mapreduce
 hadoop_mapred_home=/usr/lib/hadoop-mapreduce
 EOF
 
   # If oozie installed, add hue as proxy user for oozie
-  if [[ -f /etc/oozie/conf/oozie-site.xml ]];
-  then
+  if [[ -f /etc/oozie/conf/oozie-site.xml ]]; then
     bdconfig set_property \
       --configuration_file '/etc/oozie/conf/oozie-site.xml' \
       --name 'oozie.service.ProxyUserService.proxyuser.hue.hosts' --value '*' \
       --create_if_absent \
-      --clobber \
-      || err 'Unable to set hadoop.proxyuser.hue.groups'
+      --clobber ||
+      err 'Unable to set hadoop.proxyuser.hue.groups'
 
     bdconfig set_property \
       --configuration_file '/etc/oozie/conf/oozie-site.xml' \
       --name 'oozie.service.ProxyUserService.proxyuser.hue.groups' --value '*' \
       --create_if_absent \
-      --clobber \
-      || err 'Unable to set hadoop.proxyuser.hue.groups'
+      --clobber ||
+      err 'Unable to set hadoop.proxyuser.hue.groups'
 
     systemctl restart oozie || err "Unable to restart oozie"
   else
@@ -120,7 +119,7 @@ EOF
   fi
 
   # Fix webhdfs_url
-  sed -i 's/'"${old_hdfs_url}"'/'"${new_hdfs_url}"'/' /etc/hue/conf/hue.ini
+  sed -i "s/${old_hdfs_url}/${new_hdfs_url}/" /etc/hue/conf/hue.ini
   # Uncomment every line containing localhost, replacing localhost with the FQDN
   sed -i "s/#*\([^#]*=.*\)localhost/\1$(hostname --fqdn)/" /etc/hue/conf/hue.ini
 
@@ -129,16 +128,19 @@ EOF
     /etc/hue/conf/hue.ini
 
   # Make hive warehouse directory
-  hdfs dfs -mkdir /user/hive/warehouse || err "Unable to create folder"
+  local warehause_dir="/user/hive/warehouse"
+  hdfs dfs -mkdir "${warehause_dir}" ||
+    hdfs dfs -stat "${warehause_dir}" ||
+    err "Unable to create '${warehause_dir}' folder"
 
   bdconfig set_property \
-      --configuration_file '/etc/hue/conf/hive-site.xml' \
-      --create_if_absent \
-      --clobber \
-      --name 'hive.metastore.warehouse.dir' --value '/user/hive/warehouse'
+    --configuration_file '/etc/hue/conf/hive-site.xml' \
+    --create_if_absent \
+    --clobber \
+    --name 'hive.metastore.warehouse.dir' --value '/user/hive/warehouse'
 
   # Configure Desktop Database to use mysql
-  perl -i -0777 -pe 's/'"${old_mysql_settings}"'/'"${new_mysql_settings}"'/' /etc/hue/conf/hue.ini
+  perl -i -0777 -pe "s/${old_mysql_settings}/${new_mysql_settings}/" /etc/hue/conf/hue.ini
 
   # Comment out sqlite3 configuration
   sed -i 's/engine=sqlite3/## engine=sqlite3/' /etc/hue/conf/hue.ini
@@ -147,14 +149,14 @@ EOF
   sed -i 's/name=\/var\/lib\/hue\/desktop.db/name=hue/' /etc/hue/conf/hue.ini
 
   # Set random secret key
-  sed -i 's/'"secret_key=.*"'/'"secret_key=${random}"'/' /etc/hue/conf/hue.ini
+  sed -i "s/secret_key=.*/secret_key=${random}/" /etc/hue/conf/hue.ini
 
   # Create database, give hue user permissions
-  mysql -u root -proot-password -e " \
-    CREATE DATABASE hue; \
-    CREATE USER 'hue'@'localhost' IDENTIFIED BY '${hue_password}'; \
-    GRANT ALL PRIVILEGES ON hue.* TO 'hue'@'localhost';" \
-    || err "Unable to create database"
+  mysql -u root -proot-password -e "
+      CREATE DATABASE hue;
+      CREATE USER 'hue'@'localhost' IDENTIFIED BY '${hue_password}';
+      GRANT ALL PRIVILEGES ON hue.* TO 'hue'@'localhost';" ||
+    err "Unable to create database"
 
   # Restart mysql
   systemctl restart mysql || err "Unable to restart mysql"
@@ -172,9 +174,11 @@ EOF
 
 function main() {
   # Determine the role of this node
-  local role=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+  local master_hostname
+  master_hostname=$(/usr/share/google/get_metadata_value attributes/dataproc-master)
   # Only run on the master node of the cluster
-  if [[ "${role}" == 'Master' ]]; then
+  if [[ "${HOSTNAME}" == "${master_hostname}" ]]; then
+    # Start Flink master only on the master node ("0"-master in HA mode)
     update_apt_get || err "Unable to update apt-get"
     install_hue_and_configure || err "Hue install process failed"
   else

--- a/hue/hue.sh
+++ b/hue/hue.sh
@@ -14,7 +14,7 @@
 #
 # This script installs HUE on a master node within a Google Cloud Dataproc cluster.
 
-set -Eeuxo pipefail
+set -euxo pipefail
 
 function random_string() {
   tr </dev/urandom -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1

--- a/hue/test_hue.py
+++ b/hue/test_hue.py
@@ -12,45 +12,37 @@ class HueTestCase(DataprocTestCase):
 
     def verify_instance(self, name):
         self.upload_test_file(
-            os.path.join(
-                os.path.dirname(os.path.abspath(__file__)),
-                self.TEST_SCRIPT_FILE_NAME
-            ),
-            name)
+            os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         self.TEST_SCRIPT_FILE_NAME), name)
         self.__run_test_file(name)
         self.remove_test_script(self.TEST_SCRIPT_FILE_NAME, name)
 
     def __run_test_file(self, name):
-        cmd = 'gcloud compute ssh {} -- "python3 {} "'.format(
-            name,
-            self.TEST_SCRIPT_FILE_NAME
-        )
+        cmd = 'gcloud compute ssh {} --command="python3 {}"'.format(
+            name, self.TEST_SCRIPT_FILE_NAME)
         ret_code, stdout, stderr = self.run_command(cmd)
-        self.assertEqual(ret_code, 0, "Failed to run test file. Error: {}".format(stderr))
+        self.assertEqual(
+            ret_code, 0, "Failed to run test file.{}".format(
+                "\nCommand:\n{}\nLast error:\n{}".format(cmd, stderr)))
 
-    @parameterized.expand([
-        ("SINGLE", "1.0", ["m"]),
-        ("STANDARD", "1.0", ["m", "w-0"]),
-        ("HA", "1.0", ["m-0", "m-1", "m-2", "w-0"]),
-        ("SINGLE", "1.1", ["m"]),
-        ("STANDARD", "1.1", ["m", "w-0"]),
-        ("HA", "1.1", ["m-0", "m-1", "m-2", "w-0"]),
-        ("SINGLE", "1.2", ["m"]),
-        ("STANDARD", "1.2", ["m", "w-0"]),
-        ("HA", "1.2", ["m-0", "m-1", "m-2", "w-0"]),
-        ("SINGLE", "1.3", ["m"]),
-        ("STANDARD", "1.3", ["m", "w-0"]),
-        ("HA", "1.3", ["m-0", "m-1", "m-2", "w-0"]),
-    ], testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+    @parameterized.expand(
+        [
+            # ("SINGLE", "1.1", ["m"]),
+            # ("STANDARD", "1.1", ["m", "w-0"]),
+            # ("HA", "1.1", ["m-0", "m-1", "m-2", "w-0"]),
+            ("SINGLE", "1.2", ["m"]),
+            ("STANDARD", "1.2", ["m", "w-0"]),
+            ("HA", "1.2", ["m-0", "m-1", "m-2", "w-0"]),
+            ("SINGLE", "1.3", ["m"]),
+            ("STANDARD", "1.3", ["m", "w-0"]),
+            ("HA", "1.3", ["m-0", "m-1", "m-2", "w-0"]),
+        ],
+        testcase_func_name=DataprocTestCase.generate_verbose_test_name)
     def test_hue(self, configuration, dataproc_version, machine_suffixes):
         self.createCluster(configuration, self.INIT_ACTIONS, dataproc_version)
         for machine_suffix in machine_suffixes:
-            self.verify_instance(
-                "{}-{}".format(
-                    self.getClusterName(),
-                    machine_suffix
-                )
-            )
+            self.verify_instance("{}-{}".format(self.getClusterName(),
+                                                machine_suffix))
 
 
 if __name__ == '__main__':

--- a/hue/test_hue.py
+++ b/hue/test_hue.py
@@ -1,7 +1,8 @@
+import os
 import unittest
 
 from parameterized import parameterized
-import os
+
 from integration_tests.dataproc_test_case import DataprocTestCase
 
 

--- a/hue/verify_hue_running.py
+++ b/hue/verify_hue_running.py
@@ -4,6 +4,8 @@
 import requests
 import socket
 import subprocess
+import sys
+import time
 
 BASE = 'localhost'
 PORT = 8888
@@ -14,12 +16,19 @@ class Hue(object):
         self.path = 'http://{}:{}/accounts/login/?next=/'.format(base, port)
         self.host = socket.gethostname()
 
-    def get_response_code(self):
-        try:
-            response = requests.get(self.path)
-            return response.status_code
-        except requests.exceptions.RequestException:
-            return None
+    def get_response_code(self, retries=0):
+        while True:
+            try:
+                response = requests.get(self.path)
+                return response.status_code
+            except requests.exceptions.RequestException as re:
+                if retries > 0:
+                    retries -= 1
+                    time.sleep(3)
+                    continue
+                print("Failed to get Hue status code: {}".format(re),
+                      file=sys.stderr)
+                return None
 
     def get_main_master(self):
         cmd = '/usr/share/google/get_metadata_value attributes/dataproc-master'
@@ -52,12 +61,13 @@ def main():
     hue = Hue(BASE, PORT)
     is_main_master = hue.is_main_master()
     if is_main_master:
-        code = hue.get_response_code()
+        code = hue.get_response_code(retries=100)
         assert code is not None, "NOK - Failed to get a status code"
         assert code < 300, "NOK - Expected to see UI running on this node"
     else:
         code = hue.get_response_code()
         assert code is None, "NOK - Expected to not see UI running on this node"
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Failure:
```
======================================================================
FAIL: test_hue.mode: STANDARD.version: 1_0.random_prefix: mbxg (hue.test_hue.HueTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/idv/.local/lib/python3.6/site-packages/parameterized/parameterized.py", line 518, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/hue/test_hue.py", line 51, in test_hue
    machine_suffix
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/hue/test_hue.py", line 20, in verify_instance
    self.__run_test_file(name)
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/hue/test_hue.py", line 29, in __run_test_file
    self.assertEqual(ret_code, 0, "Failed to run test file. Error: {}".format(stderr))
AssertionError: 1 != 0 : Failed to run test file. Error: Pseudo-terminal will not be allocated because stdin is not a terminal.
Traceback (most recent call last):
  File "verify_hue_running.py", line 63, in <module>
    main()
  File "verify_hue_running.py", line 56, in main
    assert code is not None, "NOK - Failed to get a status code"
AssertionError: NOK - Failed to get a status code
```