### PR TITLE
Fix GPU integration test

### DIFF
--- a/gpu/test_install_gpu_driver.py
+++ b/gpu/test_install_gpu_driver.py
@@ -5,78 +5,78 @@ from integration_tests.dataproc_test_case import DataprocTestCase
 
 
 class NvidiaGpuDriverTestCase(DataprocTestCase):
-  COMPONENT = 'gpu'
-  INIT_ACTIONS = ['gpu/install_gpu_driver.sh']
-  MASTER_GPU_TYPE = 'type=nvidia-tesla-v100'
-  WORKER_GPU_TYPE = 'type=nvidia-tesla-v100'
+    COMPONENT = 'gpu'
+    INIT_ACTIONS = ['gpu/install_gpu_driver.sh']
+    MASTER_GPU_TYPE = 'type=nvidia-tesla-v100'
+    WORKER_GPU_TYPE = 'type=nvidia-tesla-v100'
 
-  @classmethod
-  def setUpClass(cls):
-    super().setUpClass()
-    _, region, _ = cls.run_command("gcloud config get-value compute/region")
-    cls.REGION = region.strip() or "global"
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _, region, _ = cls.run_command(
+            "gcloud config get-value compute/region")
+        _, zone, _ = cls.run_command("gcloud config get-value compute/zone")
+        cls.REGION = region.strip() or zone.strip()[:-2]
 
-  def verify_instance(self, name):
-    ret_code, stdout, stderr = self.run_command(
-      'gcloud compute ssh {} --command '
-      '"nvidia-smi"'.format(name)
-    )
-    self.assertEqual(ret_code, 0,
-                     "Failed to validate cluster. Error: {}".format(stderr))
+    def verify_instance(self, name):
+        ret_code, stdout, stderr = self.run_command(
+            'gcloud compute ssh {} --command="nvidia-smi"'.format(name))
+        self.assertEqual(
+            ret_code, 0,
+            "Failed to validate cluster. Error: {}".format(stderr))
 
-  def verify_instance_gpu_agent(self, name):
-    ret_code, stdout, stderr = self.run_command(
-      'gcloud compute ssh {} --command '
-      '"systemctl status gpu_utilization_agent.service"'.format(name)
-    )
-    self.assertEqual(ret_code, 0,
-                     "Failed to validate cluster. Error: {}".format(stderr))
+    def verify_instance_gpu_agent(self, name):
+        ret_code, stdout, stderr = self.run_command(
+            'gcloud compute ssh {} --command="{}"'.format(
+                name, "systemctl status gpu_utilization_agent.service"))
+        self.assertEqual(
+            ret_code, 0,
+            "Failed to validate cluster. Error: {}".format(stderr))
 
-  @parameterized.expand([
-    ("STANDARD", "1.3", ["m"], MASTER_GPU_TYPE, WORKER_GPU_TYPE),
-  ], testcase_func_name=DataprocTestCase.generate_verbose_test_name)
-  def test_install_gpu(self, configuration, dataproc_version, machine_suffixes,
-                       master_accelerator, worker_accelerator):
-    init_actions = self.INIT_ACTIONS
-    self.createCluster(configuration, init_actions, dataproc_version,
-                       beta=True,
-                       master_accelerator=master_accelerator,
-                       worker_accelerator=worker_accelerator,
-                       metadata='install_gpu_agent=false')
-    for machine_suffix in machine_suffixes:
-      self.verify_instance(
-        "{}-{}".format(
-          self.getClusterName(),
-          machine_suffix
-        )
-      )
+    @parameterized.expand(
+        [
+            ("STANDARD", "1.3", ["m"], MASTER_GPU_TYPE, WORKER_GPU_TYPE),
+        ],
+        testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+    def test_install_gpu(self, configuration, dataproc_version,
+                         machine_suffixes, master_accelerator,
+                         worker_accelerator):
+        init_actions = self.INIT_ACTIONS
+        self.createCluster(configuration,
+                           init_actions,
+                           dataproc_version,
+                           beta=True,
+                           master_accelerator=master_accelerator,
+                           worker_accelerator=worker_accelerator,
+                           metadata='install_gpu_agent=false')
+        for machine_suffix in machine_suffixes:
+            self.verify_instance("{}-{}".format(self.getClusterName(),
+                                                machine_suffix))
 
-  @parameterized.expand([
-    ("STANDARD", "1.0", ["m"], MASTER_GPU_TYPE, WORKER_GPU_TYPE),
-    ("STANDARD", "1.1", ["m"], MASTER_GPU_TYPE, WORKER_GPU_TYPE),
-    ("STANDARD", "1.2", ["m"], MASTER_GPU_TYPE, WORKER_GPU_TYPE),
-    ("STANDARD", "1.3", ["m"], MASTER_GPU_TYPE, WORKER_GPU_TYPE),
-  ], testcase_func_name=DataprocTestCase.generate_verbose_test_name)
-  def test_install_gpu_agent(self, configuration, dataproc_version,
-                             machine_suffixes, master_accelerator,
-                             worker_accelerator):
+    @parameterized.expand(
+        [
+            ("STANDARD", "1.2", ["m"], MASTER_GPU_TYPE, WORKER_GPU_TYPE),
+            ("STANDARD", "1.3", ["m"], MASTER_GPU_TYPE, WORKER_GPU_TYPE),
+        ],
+        testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+    def test_install_gpu_agent(self, configuration, dataproc_version,
+                               machine_suffixes, master_accelerator,
+                               worker_accelerator):
 
-    init_actions = self.INIT_ACTIONS
-    self.createCluster(configuration, init_actions, dataproc_version,
-                       beta=True,
-                       master_accelerator=master_accelerator,
-                       worker_accelerator=worker_accelerator,
-                       metadata='install_gpu_agent=true',
-                       scopes='https://www.googleapis.com/auth/monitoring.write'
-                       )
-    for machine_suffix in machine_suffixes:
-      self.verify_instance_gpu_agent(
-        "{}-{}".format(
-          self.getClusterName(),
-          machine_suffix
-        )
-      )
+        init_actions = self.INIT_ACTIONS
+        self.createCluster(
+            configuration,
+            init_actions,
+            dataproc_version,
+            beta=True,
+            master_accelerator=master_accelerator,
+            worker_accelerator=worker_accelerator,
+            metadata='install_gpu_agent=true',
+            scopes='https://www.googleapis.com/auth/monitoring.write')
+        for machine_suffix in machine_suffixes:
+            self.verify_instance_gpu_agent("{}-{}".format(
+                self.getClusterName(), machine_suffix))
 
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()


### PR DESCRIPTION
Disables init action test for 1.1 and 1.2 images.

Failure:
```
======================================================================
FAIL: test_install_gpu_agent.mode: STANDARD.version: 1_1.random_prefix: 3uoo (gpu.test_install_gpu_driver.NvidiaGpuDriverTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/idv/.local/lib/python3.6/site-packages/parameterized/parameterized.py", line 518, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/gpu/test_install_gpu_driver.py", line 70, in test_install_gpu_agent
    scopes='https://www.googleapis.com/auth/monitoring.write'
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/integration_tests/dataproc_test_case.py", line 109, in createCluster
    "Failed to create Cluster {}. Error: {}".format(self.name, stderr))
AssertionError: 1 != 0 : Failed to create Cluster test-gpu-standard-1-1-20190608-213713-cekf. Error: ERROR: (gcloud.beta.dataproc.clusters.create) INVALID_ARGUMENT: Image version '1.1.113-debian9' does not support accelerators. Minimum supported image version is '1.2'.
- '@type': type.googleapis.com/google.rpc.DebugInfo
  detail: "[ORIGINAL ERROR] generic::invalid_argument: com.google.cloud.hadoop.services.common.error.DataprocException:\
    \ Image version '1.1.113-debian9' does not support accelerators. Minimum supported\
    \ image version is '1.2'. (INVALID_ARGUMENT) [google.rpc.error_details_ext] {\
    \ message: \"Image version \\'1.1.113-debian9\\' does not support accelerators.\
    \ Minimum supported image version is \\'1.2\\'.\" }"
```