### PR TITLE
Fix Solr integration test

### DIFF
--- a/solr/test_solr.py
+++ b/solr/test_solr.py
@@ -1,8 +1,10 @@
 """
 This module provides testing functionality of the Apache Solr Init Action.
 """
-import unittest
+
 import os
+import unittest
+
 from parameterized import parameterized
 
 from integration_tests.dataproc_test_case import DataprocTestCase
@@ -15,39 +17,34 @@ class SolrTestCase(DataprocTestCase):
 
     def verify_instance(self, name):
         self.upload_test_file(
-            os.path.join(
-                os.path.dirname(os.path.abspath(__file__)),
-                self.TEST_SCRIPT_FILE_NAME),
-            name)
+            os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         self.TEST_SCRIPT_FILE_NAME), name)
         self.__run_test_script(name)
         self.remove_test_script(self.TEST_SCRIPT_FILE_NAME, name)
 
     def __run_test_script(self, name):
         ret_code, stdout, stderr = self.run_command(
-            'gcloud compute ssh {} -- "python {}"'.format(
-                name,
-                self.TEST_SCRIPT_FILE_NAME,
-            )
-        )
-        self.assertEqual(ret_code, 0, "Failed to validate cluster. Last error: {}".format(stderr))
+            'gcloud compute ssh {} --command="python3 {}"'.format(
+                name, self.TEST_SCRIPT_FILE_NAME))
+        self.assertEqual(
+            ret_code, 0,
+            "Failed to validate cluster. Last error: {}".format(stderr))
 
-    @parameterized.expand([
-        ("SINGLE", "1.2", ["m"]),
-        ("STANDARD", "1.2", ["m"]),
-        ("HA", "1.2", ["m-0"]),
-        ("SINGLE", "1.3", ["m"]),
-        ("STANDARD", "1.3", ["m"]),
-        ("HA", "1.3", ["m-0"]),
-    ], testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+    @parameterized.expand(
+        [
+            ("SINGLE", "1.2", ["m"]),
+            ("STANDARD", "1.2", ["m"]),
+            ("HA", "1.2", ["m-0"]),
+            ("SINGLE", "1.3", ["m"]),
+            ("STANDARD", "1.3", ["m"]),
+            ("HA", "1.3", ["m-0"]),
+        ],
+        testcase_func_name=DataprocTestCase.generate_verbose_test_name)
     def test_solr(self, configuration, dataproc_version, machine_suffixes):
         self.createCluster(configuration, self.INIT_ACTIONS, dataproc_version)
         for machine_suffix in machine_suffixes:
-            self.verify_instance(
-                "{}-{}".format(
-                    self.getClusterName(),
-                    machine_suffix
-                )
-            )
+            self.verify_instance("{}-{}".format(self.getClusterName(),
+                                                machine_suffix))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Failure:
```
======================================================================
FAIL: test_solr.mode: SINGLE.version: 1_2.random_prefix: 5mfe (solr.test_solr.SolrTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/google/home/idv/.local/lib/python3.6/site-packages/parameterized/parameterized.py", line 518, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/solr/test_solr.py", line 48, in test_solr
    machine_suffix
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/solr/test_solr.py", line 22, in verify_instance
    self.__run_test_script(name)
  File "/usr/local/google/home/idv/dev/src/dataproc-initialization-actions/solr/test_solr.py", line 32, in __run_test_script
    self.assertEqual(ret_code, 0, "Failed to validate cluster. Last error: {}".format(stderr))
AssertionError: 1 != 0 : Failed to validate cluster. Last error: Pseudo-terminal will not be allocated because stdin is not a terminal.
Traceback (most recent call last):
  File "verify_solr.py", line 101, in <module>
    main()
  File "verify_solr.py", line 97, in main
    run_test_query()
  File "verify_solr.py", line 87, in run_test_query
    out_json = json.loads(stdout)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```