### PR TITLE
Pin Conda and Python versions when setting up Conda environment

### DIFF
--- a/conda/__init__.py
+++ b/conda/__init__.py
@@ -1,0 +1,2 @@
+# This file is required for integration tests
+

--- a/conda/__init__.py
+++ b/conda/__init__.py
@@ -1,2 +1,1 @@
 # This file is required for integration tests
-

--- a/conda/install-conda-env.sh
+++ b/conda/install-conda-env.sh
@@ -77,6 +77,21 @@ if [[ ! $CONDA_ENV_NAME == 'root' ]]
     source activate $CONDA_ENV_NAME
 fi
 
+# Pin base conda and Python versions to minor version to prevent unexpected upgrades
+# while installing conda and pip packages
+CONDA_BASE_PATH=$(conda info --base)
+CONDA_PINNED_FILE="${CONDA_BASE_PATH}/conda-meta/pinned"
+function pin_component_version() {
+  local component=$1
+
+  version=$(conda list "${component}" \
+      | grep -E "^${component}\s+" | sed -E "s/[ ]+/ /g" \
+      | cut -f2 -d' ' | cut -f1,2 -d'.')
+  echo "${component} ${version}.*" >> "${CONDA_PINNED_FILE}"
+}
+pin_component_version conda
+pin_component_version python
+
 # 3. Install conda and pip packages (if specified)
 if [[ ! -z "${CONDA_PACKAGES}" ]]; then
     echo "Installing conda packages for $CONDA_ENV_NAME..."

--- a/conda/install-conda-env.sh
+++ b/conda/install-conda-env.sh
@@ -79,7 +79,12 @@ fi
 
 # Pin base conda and Python versions to minor version to prevent unexpected upgrades
 # while installing conda and pip packages
-CONDA_BASE_PATH=$(conda info --base)
+if conda info --base; then
+  CONDA_BASE_PATH=$(conda info --base)
+else
+  # Older versions of conda don't support the --base flag
+  CONDA_BASE_PATH=$(conda info | grep 'default environment' | sed -E 's:\s+default environment\s+\:\s+(.*):\1:g')
+fi
 CONDA_PINNED_FILE="${CONDA_BASE_PATH}/conda-meta/pinned"
 function pin_component_version() {
   local component=$1

--- a/conda/test_conda.py
+++ b/conda/test_conda.py
@@ -9,66 +9,78 @@ CONDA_BINARY = "/opt/conda/bin/conda"
 PIP_BINARY = "/opt/conda/bin/pip"
 PYTHON_VERSION_KEY = "python_version"
 
+
 class CondaTestCase(DataprocTestCase):
-  COMPONENT = "conda"
-  INIT_ACTIONS = ["conda/bootstrap-conda.sh", "conda/install-conda-env.sh"]
+    COMPONENT = "conda"
+    INIT_ACTIONS = ["conda/bootstrap-conda.sh", "conda/install-conda-env.sh"]
 
-  def _verify_python_version(self, expected_python):
-    _, stdout, _ = self.assert_instance_command(self.getClusterName() + "-m", CONDA_BINARY + " info --json")
-    python_version = json.loads(stdout)[PYTHON_VERSION_KEY]
-    self.assertTrue(python_version.startswith(expected_python),
-                    "Unexpected Python version. Wanted {}, got {}".format(expected_python, python_version))
+    # Test packages
+    CONDA_PKGS = ["numpy", "pandas", "jupyter"]
+    PIP_PKGS = ["pandas-gbq"]
 
-  def _verify_conda_packages(self, conda_packages):
-    _, stdout, _ = self.assert_instance_command(self.getClusterName() + "-m", CONDA_BINARY + " list")
-    installed_packages = self._parse_packages(stdout)
-    for package in conda_packages:
-      self.assertIn(package, installed_packages,
-                    "Expected package {} to be installed, but wasn't. Packages installed: {}".format(package, installed_packages))
+    def _verify_python_version(self, instance, expected_python):
+        _, stdout, _ = self.assert_instance_command(
+            instance, CONDA_BINARY + " info --json")
+        python_version = json.loads(stdout)[PYTHON_VERSION_KEY]
+        self.assertTrue(
+            python_version.startswith(expected_python),
+            "Unexpected Python version. Wanted {}, got {}".format(
+                expected_python, python_version))
 
+    def _verify_conda_packages(self, instance, conda_packages):
+        _, stdout, _ = self.assert_instance_command(instance,
+                                                    CONDA_BINARY + " list")
+        installed_packages = self._parse_packages(stdout)
+        for package in conda_packages:
+            self.assertIn(
+                package, installed_packages,
+                "Expected package {} to be installed, but wasn't."
+                " Packages installed: {}".format(package, installed_packages))
 
-  def _verify_pip_packages(self, pip_packages):
-    _, stdout, _ = self.assert_instance_command(self.getClusterName() + "-m", PIP_BINARY + " list")
-    installed_packages = self._parse_packages(stdout)
-    for package in pip_packages:
-      self.assertIn(package, installed_packages,
-                    "Expected package {} to be installed, but wasn't. Packages installed: {}".format(package, installed_packages))
+    def _verify_pip_packages(self, instance, pip_packages):
+        _, stdout, _ = self.assert_instance_command(instance,
+                                                    PIP_BINARY + " list")
+        installed_packages = self._parse_packages(stdout)
+        for package in pip_packages:
+            self.assertIn(
+                package, installed_packages,
+                "Expected package {} to be installed, but wasn't."
+                " Packages installed: {}".format(package, installed_packages))
 
-  def _parse_packages(self, stdout):
-    packages = set()
-    for line in stdout.splitlines():
-      if not line.startswith("#"):
-        packages.add(line.split()[0])
+    @staticmethod
+    def _parse_packages(stdout):
+        return set(l.split()[0] for l in stdout.splitlines()
+                   if not l.startswith("#"))
 
-    return packages
+    @parameterized.expand(
+        [
+            ("STANDARD", "1.0", "3.5", [], []),
+            ("STANDARD", "1.0", "3.5", CONDA_PKGS, PIP_PKGS),
+            ("STANDARD", "1.1", "3.5", [], []),
+            ("STANDARD", "1.1", "3.5", CONDA_PKGS, PIP_PKGS),
+            ("STANDARD", "1.2", "3.6", [], []),
+            ("STANDARD", "1.2", "3.6", CONDA_PKGS, PIP_PKGS),
+            ("STANDARD", "1.3", "3.6", [], []),
+            ("STANDARD", "1.3", "3.6", CONDA_PKGS, PIP_PKGS),
+            ("STANDARD", "1.4", "3.6", [], []),
+            ("STANDARD", "1.4", "3.6", CONDA_PKGS, PIP_PKGS),
+        ],
+        testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+    def test_conda(self, configuration, dataproc_version, expected_python,
+                   conda_packages, pip_packages):
+        metadata = "'CONDA_PACKAGES={},PIP_PACKAGES={}'".format(
+            " ".join(conda_packages), " ".join(pip_packages))
+        self.createCluster(configuration,
+                           self.INIT_ACTIONS,
+                           dataproc_version,
+                           machine_type="n1-standard-2",
+                           metadata=metadata)
 
-  @parameterized.expand(
-      [
-          ("STANDARD", "1.0", [], [], "3.5"),
-          ("STANDARD", "1.0", ["numpy", "pandas", "jupyter"], ["pandas-gbq"], "3.5"),
-          ("STANDARD", "1.1", [], [], "3.5"),
-          ("STANDARD", "1.1", ["numpy", "pandas", "jupyter"], ["pandas-gbq"], "3.5"),
-          ("STANDARD", "1.2", [], [], "3.6"),
-          ("STANDARD", "1.2", ["numpy", "pandas", "jupyter"], ["pandas-gbq"], "3.6"),
-          ("STANDARD", "1.3", [], [], "3.6"),
-          ("STANDARD", "1.3", ["numpy", "pandas", "jupyter"], ["pandas-gbq"], "3.6"),
-          ("STANDARD", "1.4", [], [], "3.6"),
-          ("STANDARD", "1.4", ["numpy", "pandas", "jupyter"], ["pandas-gbq"], "3.6"),
-      ],
-      testcase_func_name=DataprocTestCase.generate_verbose_test_name)
-  def test_conda(self, configuration, dataproc_version, conda_packages, pip_packages, expected_python):
-    metadata = "'CONDA_PACKAGES={},PIP_PACKAGES={}'".format(
-        " ".join(conda_packages), " ".join(pip_packages))
-    self.createCluster(configuration,
-                       self.INIT_ACTIONS,
-                       dataproc_version,
-                       machine_type="n1-standard-2",
-                       metadata=metadata)
-
-    self._verify_python_version(expected_python)
-    self._verify_pip_packages(pip_packages)
-    self._verify_conda_packages(conda_packages)
+        instance_name = self.getClusterName() + "-m"
+        self._verify_python_version(instance_name, expected_python)
+        self._verify_pip_packages(instance_name, pip_packages)
+        self._verify_conda_packages(instance_name, conda_packages)
 
 
 if __name__ == "__main__":
-  unitttest.main()
+    unittest.main()

--- a/conda/test_conda.py
+++ b/conda/test_conda.py
@@ -1,0 +1,74 @@
+import json
+import unittest
+
+from parameterized import parameterized
+
+from integration_tests.dataproc_test_case import DataprocTestCase
+
+CONDA_BINARY = "/opt/conda/bin/conda"
+PIP_BINARY = "/opt/conda/bin/pip"
+PYTHON_VERSION_KEY = "python_version"
+
+class CondaTestCase(DataprocTestCase):
+  COMPONENT = "conda"
+  INIT_ACTIONS = ["conda/bootstrap-conda.sh", "conda/install-conda-env.sh"]
+
+  def _verify_python_version(self, expected_python):
+    _, stdout, _ = self.assert_instance_command(self.getClusterName() + "-m", CONDA_BINARY + " info --json")
+    python_version = json.loads(stdout)[PYTHON_VERSION_KEY]
+    self.assertTrue(python_version.startswith(expected_python),
+                    "Unexpected Python version. Wanted {}, got {}".format(expected_python, python_version))
+
+  def _verify_conda_packages(self, conda_packages):
+    _, stdout, _ = self.assert_instance_command(self.getClusterName() + "-m", CONDA_BINARY + " list")
+    installed_packages = self._parse_packages(stdout)
+    for package in conda_packages:
+      self.assertIn(package, installed_packages,
+                    "Expected package {} to be installed, but wasn't. Packages installed: {}".format(package, installed_packages))
+
+
+  def _verify_pip_packages(self, pip_packages):
+    _, stdout, _ = self.assert_instance_command(self.getClusterName() + "-m", PIP_BINARY + " list")
+    installed_packages = self._parse_packages(stdout)
+    for package in pip_packages:
+      self.assertIn(package, installed_packages,
+                    "Expected package {} to be installed, but wasn't. Packages installed: {}".format(package, installed_packages))
+
+  def _parse_packages(self, stdout):
+    packages = set()
+    for line in stdout.splitlines():
+      if not line.startswith("#"):
+        packages.add(line.split()[0])
+
+    return packages
+
+  @parameterized.expand(
+      [
+          ("STANDARD", "1.0", [], [], "3.5"),
+          ("STANDARD", "1.0", ["numpy", "pandas", "jupyter"], ["pandas-gbq"], "3.5"),
+          ("STANDARD", "1.1", [], [], "3.5"),
+          ("STANDARD", "1.1", ["numpy", "pandas", "jupyter"], ["pandas-gbq"], "3.5"),
+          ("STANDARD", "1.2", [], [], "3.6"),
+          ("STANDARD", "1.2", ["numpy", "pandas", "jupyter"], ["pandas-gbq"], "3.6"),
+          ("STANDARD", "1.3", [], [], "3.6"),
+          ("STANDARD", "1.3", ["numpy", "pandas", "jupyter"], ["pandas-gbq"], "3.6"),
+          ("STANDARD", "1.4", [], [], "3.6"),
+          ("STANDARD", "1.4", ["numpy", "pandas", "jupyter"], ["pandas-gbq"], "3.6"),
+      ],
+      testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+  def test_conda(self, configuration, dataproc_version, conda_packages, pip_packages, expected_python):
+    metadata = "'CONDA_PACKAGES={},PIP_PACKAGES={}'".format(
+        " ".join(conda_packages), " ".join(pip_packages))
+    self.createCluster(configuration,
+                       self.INIT_ACTIONS,
+                       dataproc_version,
+                       machine_type="n1-standard-2",
+                       metadata=metadata)
+
+    self._verify_python_version(expected_python)
+    self._verify_pip_packages(pip_packages)
+    self._verify_conda_packages(conda_packages)
+
+
+if __name__ == "__main__":
+  unitttest.main()

--- a/rstudio/__init__.py
+++ b/rstudio/__init__.py
@@ -1,2 +1,1 @@
 # This file is required for integration tests
-

--- a/rstudio/test_rstudio.py
+++ b/rstudio/test_rstudio.py
@@ -7,28 +7,29 @@ from integration_tests.dataproc_test_case import DataprocTestCase
 
 
 class RStudioTestCase(DataprocTestCase):
-  COMPONENT = 'rstudio'
-  INIT_ACTIONS = ['rstudio/rstudio.sh']
+    COMPONENT = 'rstudio'
+    INIT_ACTIONS = ['rstudio/rstudio.sh']
 
-  @parameterized.expand(
-      [
-          ("SINGLE", "1.0", "rstudio", "password"),
-          ("SINGLE", "1.1", "rstudio", "password"),
-          ("SINGLE", "1.2", "rstudio", "password"),
-          ("SINGLE", "1.3", "rstudio", "password"),
-          ("SINGLE", "1.3", "", "password"),  # Test with default username
-          ("SINGLE", "1.3", "rstudio", ""),  # Test with no auth
-          ("SINGLE", "1.3", "", ""),  # Test with default username and no auth
-          ("SINGLE", "1.4", "rstudio", "password"),
-      ],
-      testcase_func_name=DataprocTestCase.generate_verbose_test_name)
-  def test_rstudio(self, configuration, dataproc_version, user, password):
-    metadata = "rstudio-password={}".format(password)
-    if user:
-      metadata += ",rstudio-user={}".format(user)
-    self.createCluster(configuration,
-                   self.INIT_ACTIONS,
-                   dataproc_version,
-                   metadata=metadata)
-    instance_name = self.getClusterName() + "-m"
-    self.assert_instance_command(instance_name, "curl http://{}:8787".format(instance_name))
+    @parameterized.expand(
+        [
+            ("SINGLE", "1.0", "rstudio", "password"),
+            ("SINGLE", "1.1", "rstudio", "password"),
+            ("SINGLE", "1.2", "rstudio", "password"),
+            ("SINGLE", "1.3", "rstudio", "password"),
+            ("SINGLE", "1.3", "", "password"),  # default username
+            ("SINGLE", "1.3", "rstudio", ""),  # no auth
+            ("SINGLE", "1.3", "", ""),  # default username and no auth
+            ("SINGLE", "1.4", "rstudio", "password"),
+        ],
+        testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+    def test_rstudio(self, configuration, dataproc_version, user, password):
+        metadata = "rstudio-password={}".format(password)
+        if user:
+            metadata += ",rstudio-user={}".format(user)
+        self.createCluster(configuration,
+                           self.INIT_ACTIONS,
+                           dataproc_version,
+                           metadata=metadata)
+        instance_name = self.getClusterName() + "-m"
+        self.assert_instance_command(
+            instance_name, "curl http://{}:8787".format(instance_name))


### PR DESCRIPTION
This prevents Conda from automatically trying to update itself or Python when installing new packages. These updates can break the Conda installation.

For an example which is currently broken, try telling conda to install Jupyterhub and then interacting with conda on the command line.
```bash
gcloud dataproc clusters create conda-jupyterhub --initialization-actions=gs://dataproc-initialization-actions/conda/bootstrap-conda.sh,gs://dataproc-initialization-actions/conda/install-conda-env.sh --metadata 'CONDA_PACKAGES="jupyterhub"'
gcloud compute ssh conda-jupyterhub-m
conda 
Traceback (most recent call last):
  File "/opt/conda/bin/conda", line 7, in <module>
    from conda.cli import main
ModuleNotFoundError: No module named 'conda'
```