### PR TITLE
Allow disabling RStudio auth by setting blank password

### DIFF
--- a/rstudio/__init__.py
+++ b/rstudio/__init__.py
@@ -1,0 +1,2 @@
+# This file is required for integration tests
+

--- a/rstudio/rstudio.sh
+++ b/rstudio/rstudio.sh
@@ -68,9 +68,11 @@ function get_apt_key_for_debian() {
 }
 
 if [[ "${ROLE}" == 'Master' ]]; then
-  if (( ${#USER_PASSWORD} < 7 )) ; then
-    echo "You must specify a password of at least 7 characters for user \`$USER_NAME\` through metadata \`rstudio-password\`."
-    exit 1
+  if [[ ! -z ${USER_PASSWORD} ]] ; then
+    if (( ${#USER_PASSWORD} < 7 )) ; then
+      echo "You must specify a password of at least 7 characters for user \`$USER_NAME\` through metadata \`rstudio-password\`."
+      exit 1
+    fi
   fi
   if [[ -z "${USER_NAME}" ]] ; then
     echo "RStudio user name must not be empty."
@@ -103,6 +105,13 @@ if [[ "${ROLE}" == 'Master' ]]; then
   fi
   if ! [ $(id -u "${USER_NAME}") ]; then
     useradd --create-home --gid "${USER_NAME}" "${USER_NAME}"
-    echo "${USER_NAME}:${USER_PASSWORD}" | chpasswd
+    if [[ ! -z "${USER_PASSWORD}" ]] ; then
+      echo "${USER_NAME}:${USER_PASSWORD}" | chpasswd
+    fi
+  fi
+  if [[ -z "${USER_PASSWORD}" ]] ; then
+    sed -i 's:ExecStart=\(.*\):Environment=USER=rstudio\nExecStart=\1 --auth-none 1:1' /etc/systemd/system/rstudio-server.service
+    systemctl daemon-reload
+    systemctl restart rstudio-server
   fi
 fi

--- a/rstudio/rstudio.sh
+++ b/rstudio/rstudio.sh
@@ -68,11 +68,9 @@ function get_apt_key_for_debian() {
 }
 
 if [[ "${ROLE}" == 'Master' ]]; then
-  if [[ ! -z ${USER_PASSWORD} ]] ; then
-    if (( ${#USER_PASSWORD} < 7 )) ; then
-      echo "You must specify a password of at least 7 characters for user \`$USER_NAME\` through metadata \`rstudio-password\`."
-      exit 1
-    fi
+  if [[ -n ${USER_PASSWORD} ]] && (( ${#USER_PASSWORD} < 7 )) ; then
+    echo "You must specify a password of at least 7 characters for user '$USER_NAME' through metadata 'rstudio-password'."
+    exit 1
   fi
   if [[ -z "${USER_NAME}" ]] ; then
     echo "RStudio user name must not be empty."
@@ -105,7 +103,7 @@ if [[ "${ROLE}" == 'Master' ]]; then
   fi
   if ! [ $(id -u "${USER_NAME}") ]; then
     useradd --create-home --gid "${USER_NAME}" "${USER_NAME}"
-    if [[ ! -z "${USER_PASSWORD}" ]] ; then
+    if [[ -n "${USER_PASSWORD}" ]] ; then
       echo "${USER_NAME}:${USER_PASSWORD}" | chpasswd
     fi
   fi

--- a/rstudio/test_rstudio.py
+++ b/rstudio/test_rstudio.py
@@ -1,0 +1,34 @@
+import random
+import unittest
+
+from parameterized import parameterized
+
+from integration_tests.dataproc_test_case import DataprocTestCase
+
+
+class RStudioTestCase(DataprocTestCase):
+  COMPONENT = 'rstudio'
+  INIT_ACTIONS = ['rstudio/rstudio.sh']
+
+  @parameterized.expand(
+      [
+          ("SINGLE", "1.0", "rstudio", "password"),
+          ("SINGLE", "1.1", "rstudio", "password"),
+          ("SINGLE", "1.2", "rstudio", "password"),
+          ("SINGLE", "1.3", "rstudio", "password"),
+          ("SINGLE", "1.3", "", "password"),  # Test with default username
+          ("SINGLE", "1.3", "rstudio", ""),  # Test with no auth
+          ("SINGLE", "1.3", "", ""),  # Test with default username and no auth
+          ("SINGLE", "1.4", "rstudio", "password"),
+      ],
+      testcase_func_name=DataprocTestCase.generate_verbose_test_name)
+  def test_rstudio(self, configuration, dataproc_version, user, password):
+    metadata = "rstudio-password={}".format(password)
+    if user:
+      metadata += ",rstudio-user={}".format(user)
+    self.createCluster(configuration,
+                   self.INIT_ACTIONS,
+                   dataproc_version,
+                   metadata=metadata)
+    instance_name = self.getClusterName() + "-m"
+    self.assert_instance_command(instance_name, "curl http://{}:8787".format(instance_name))


### PR DESCRIPTION
If no password is provided, set the auth-none flag