### PR TITLE
Require openjdk to be authenticated

### DIFF
--- a/datalab/datalab.sh
+++ b/datalab/datalab.sh
@@ -126,9 +126,10 @@ ADD trusted.gpg /tmp/vm_trusted.gpg
 
 RUN apt-key add /tmp/vm_trusted.gpg
 RUN apt-get update
+RUN apt-get install -y openjdk-8-jre-headless
 # TODO: Remove --allow-unauthenticated after the expired gpg key problem is fixed,
 # https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/issues/619.
-RUN apt-get install -y --allow-unauthenticated hive spark-python openjdk-8-jre-headless
+RUN apt-get install -y --allow-unauthenticated hive spark-python
 
 # Workers do not run docker, so have a different python environment.
 # To run python3, you need to run the conda init action.

--- a/datalab/test_datalab.py
+++ b/datalab/test_datalab.py
@@ -42,7 +42,7 @@ class DatalabTestCase(DataprocTestCase):
                            dataproc_version,
                            metadata=metadata,
                            scopes='cloud-platform',
-                           timeout_in_minutes=20)
+                           timeout_in_minutes=30)
 
         for machine_suffix in machine_suffixes:
             self.verify_instance("{}-{}".format(self.getClusterName(),


### PR DESCRIPTION
This commit removes the passing of the `--allow-unauthenticated` flag when installing the package `openjdk-8-jre-headless.

That flag was added in #620 to work around an issue in installing the hive and spark-python packages. Since openjdk-8-jre-headless was being installed in the same command, this flag was applied to it as well, even though it was not necessary.

This change locks that back down by splitting the openjdk-8-jre-headless package in a separate command that does not include the `--allow-unauthenticated` flag.