### PR TITLE
Restart Dataproc Agent with SIGKILL signal after connectors update.

### DIFF
--- a/connectors/README.md
+++ b/connectors/README.md
@@ -1,6 +1,11 @@
----
-# NOTE: *this initialization action is deprecated because it can lead to an issue when nodes do not join cluster.*
----
+--------------------------------------------------------------------------------
+
+# NOTE: *this initialization action is deprecated*
+
+**You can update Cloud Storage Connector through `GCS_CONNECTOR_VERSION`
+metadata value on supported Dataproc images.**
+
+--------------------------------------------------------------------------------
 
 # Google Cloud Storage and BigQuery connectors
 

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -1,6 +1,6 @@
 --------------------------------------------------------------------------------
 
-# NOTE: *this initialization action is deprecated*
+# NOTE: *this initialization action is deprecated for updating Cloud Storage Connector*
 
 **You can update Cloud Storage Connector through `GCS_CONNECTOR_VERSION`
 metadata value on supported Dataproc images.**

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -11,7 +11,7 @@ MIN_CONNECTOR_VERSIONS=(
   ["gcs"]="1.7.0")
 
 # Starting from these versions connectors name changed:
-# "...-<version>-hadoop2.jar" -> "...-hadoop2-<version>.jar" 
+# "...-<version>-hadoop2.jar" -> "...-hadoop2-<version>.jar"
 declare -A NEW_NAME_MIN_CONNECTOR_VERSIONS
 NEW_NAME_MIN_CONNECTOR_VERSIONS=(
   ["bigquery"]="0.13.5"
@@ -55,13 +55,13 @@ update_connector() {
     # 1) gs://hadoop-lib/${name}/${name}-connector-hadoop2-${version}.jar
     # 2) gs://hadoop-lib/${name}/${name}-connector-${version}-hadoop2.jar
     local new_name_min_version=${NEW_NAME_MIN_CONNECTOR_VERSIONS[$name]}
-    if [[ "$(min_version "$new_name_min_version" "$version")" = "$new_name_min_version" ]]; then
+    if [[ "$(min_version "$new_name_min_version" "$version")" == "$new_name_min_version" ]]; then
       local jar_name="${name}-connector-hadoop2-${version}.jar"
     else
       local jar_name="${name}-connector-${version}-hadoop2.jar"
     fi
     gsutil cp "gs://hadoop-lib/${name}/${jar_name}" "${vm_connectors_dir}/"
-    
+
     # Update or create version-less connector link
     ln -s -f "${vm_connectors_dir}/${jar_name}" "${vm_connectors_dir}/${name}-connector.jar"
   fi
@@ -75,35 +75,12 @@ fi
 # because connectors from 1.7 branch are not compatible with previous connectors
 # versions (they have the same class relocation paths) we need to update both
 # of them, even if only one connector version is set
-if [[ -z $BIGQUERY_CONNECTOR_VERSION ]]  && [[ $GCS_CONNECTOR_VERSION = "1.7.0" ]]; then
+if [[ -z $BIGQUERY_CONNECTOR_VERSION ]] && [[ $GCS_CONNECTOR_VERSION == "1.7.0" ]]; then
   BIGQUERY_CONNECTOR_VERSION="0.11.0"
 fi
-if [[ $BIGQUERY_CONNECTOR_VERSION = "0.11.0" ]]  && [[ -z $GCS_CONNECTOR_VERSION ]]; then
+if [[ $BIGQUERY_CONNECTOR_VERSION == "0.11.0" ]] && [[ -z $GCS_CONNECTOR_VERSION ]]; then
   GCS_CONNECTOR_VERSION="1.7.0"
 fi
 
 update_connector "bigquery" "$BIGQUERY_CONNECTOR_VERSION"
 update_connector "gcs" "$GCS_CONNECTOR_VERSION"
-
-# Restarts Dataproc Agent after successful initialization
-# WARNING: this function relies on undocumented and not officially supported Dataproc Agent
-# "sentinel" files to determine successful Agent initialization and not guaranteed
-# to work in the future. Use at your own risk!
-restart_dataproc_agent() {
-  # Because Dataproc Agent should be restarted after initialization, we need to wait until
-  # it will create a sentinel file that signals initialization competition (success or failure)
-  while [[ ! -f /var/lib/google/dataproc/has_run_before ]]; do
-    sleep 1
-  done
-  # If Dataproc Agent didn't create a sentinel file that signals initialization
-  # failure then it means that initialization succeded and it should be restarted
-  if [[ ! -f /var/lib/google/dataproc/has_failed_before ]]; then
-    pkill -f com.google.cloud.hadoop.services.agent.AgentMain
-  fi
-}
-export -f restart_dataproc_agent
-
-# Schedule asynchronous Dataproc Agent restart so it will use updated connectors.
-# It could not be restarted sycnhronously because Dataproc Agent should be restarted
-# after its initialization, including init actions execution, has been completed.
-bash -c restart_dataproc_agent & disown

--- a/connectors/connectors.sh
+++ b/connectors/connectors.sh
@@ -20,16 +20,6 @@ NEW_NAME_MIN_CONNECTOR_VERSIONS=(
 BIGQUERY_CONNECTOR_VERSION=$(/usr/share/google/get_metadata_value attributes/bigquery-connector-version || true)
 GCS_CONNECTOR_VERSION=$(/usr/share/google/get_metadata_value attributes/gcs-connector-version || true)
 
-is_worker() {
-  local role
-  role="$(/usr/share/google/get_metadata_value attributes/dataproc-role || true)"
-  if [[ $role != Master ]]; then
-    true
-  else
-    false
-  fi
-}
-
 min_version() {
   echo -e "$1\n$2" | sort -r -t'.' -n -k1,1 -k2,2 -k3,3 | tail -n1
 }
@@ -94,11 +84,6 @@ fi
 
 update_connector "bigquery" "$BIGQUERY_CONNECTOR_VERSION"
 update_connector "gcs" "$GCS_CONNECTOR_VERSION"
-
-# Restart YARN NodeManager service on worker nodes so they can pick up updated GCS connector
-if is_worker; then
-  systemctl restart hadoop-yarn-nodemanager
-fi
 
 # Restarts Dataproc Agent after successful initialization
 # WARNING: this function relies on undocumented and not officially supported Dataproc Agent


### PR DESCRIPTION
Restarting Dataproc Agent using SIGTERM signal could cause cluster node loss.