### PR TITLE
Rebase PR on the master branch in presubmit

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -11,6 +11,7 @@ steps:
     entrypoint: 'bash'
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID']
     env:
+      - 'BASE_BRANCH=$BASE_BRANCH'
       - 'CLOUDSDK_COMPUTE_ZONE=us-central1-f'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -11,7 +11,7 @@ steps:
     entrypoint: 'bash'
     args: ['cloudbuild/run-presubmit-on-k8s.sh', 'gcr.io/$PROJECT_ID/init-actions-image:$BUILD_ID', '$BUILD_ID']
     env:
-      - 'BASE_BRANCH=$BASE_BRANCH'
+      - 'COMMIT_SHA=$COMMIT_SHA'
       - 'CLOUDSDK_COMPUTE_ZONE=us-central1-f'
       - 'CLOUDSDK_CONTAINER_CLUSTER=init-actions-presubmit'
 

--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -30,6 +30,7 @@ install_test_dependencies() {
 # so we can diff what changed relatively to master branch.
 initialize_git_repo() {
   git init
+  git config user.email "ia-tests@presubmit.example.com"
 
   git remote add origin "https://github.com/GoogleCloudPlatform/dataproc-initialization-actions.git"
   git fetch origin master

--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -31,6 +31,7 @@ install_test_dependencies() {
 initialize_git_repo() {
   git init
   git config user.email "ia-tests@presubmit.example.com"
+  git config user.name "ia-tests"
 
   git remote add origin "https://github.com/GoogleCloudPlatform/dataproc-initialization-actions.git"
   git fetch origin master

--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -34,17 +34,18 @@ initialize_git_repo() {
   git remote add origin "https://github.com/GoogleCloudPlatform/dataproc-initialization-actions.git"
   git fetch origin master
 
-  git reset origin/master
+  git reset "${BASE_BRANCH}"
+
+  git commit -a -m "Presubmit changes"
+
+  git rebase origin/master
 }
 
 # This function adds all changed files to git "index" and diffs them against master branch
 # to determine all changed files and looks for tests in directories with changed files.
 determine_tests_to_run() {
-  # Stage files to track their history
-  git add --all
-
   # Infer the files that changed
-  mapfile -t CHANGED_FILES < <(git diff --cached origin/master --name-only)
+  mapfile -t CHANGED_FILES < <(git diff origin/master --name-only)
   echo "Changed files: ${CHANGED_FILES[*]}"
 
   # Determines init actions directories that were changed

--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -33,10 +33,10 @@ initialize_git_repo() {
 
   git remote add origin "https://github.com/GoogleCloudPlatform/dataproc-initialization-actions.git"
   git fetch origin master
+  # Fetch all PRs to get history for PRs created from forked repos
+  git fetch origin +refs/pull/*/merge:refs/remotes/origin/pr/*
 
-  git reset "${BASE_BRANCH}"
-
-  git commit -a -m "Presubmit changes"
+  git reset --hard "${COMMIT_SHA}"
 
   git rebase origin/master
 }

--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -38,7 +38,7 @@ initialize_git_repo() {
   # Fetch all PRs to get history for PRs created from forked repos
   git fetch origin +refs/pull/*/merge:refs/remotes/origin/pr/*
 
-  git reset --hard "${COMMIT_SHA}"
+  git reset "${COMMIT_SHA}"
 
   git rebase origin/master
 }

--- a/cloudbuild/run-presubmit-on-k8s.sh
+++ b/cloudbuild/run-presubmit-on-k8s.sh
@@ -11,7 +11,7 @@ gcloud container clusters get-credentials "${CLOUDSDK_CONTAINER_CLUSTER}"
 
 kubectl run "${POD_NAME}" --generator=run-pod/v1 --image="$IMAGE" \
   --requests "cpu=2,memory=2Gi" --restart=Never \
-  --env="BASE_BRANCH=$BASE_BRANCH" \
+  --env="COMMIT_SHA=$COMMIT_SHA" \
   --command -- bash /init-actions/cloudbuild/presubmit.sh
 
 trap 'kubectl delete pods "${POD_NAME}"' EXIT

--- a/cloudbuild/run-presubmit-on-k8s.sh
+++ b/cloudbuild/run-presubmit-on-k8s.sh
@@ -11,6 +11,7 @@ gcloud container clusters get-credentials "${CLOUDSDK_CONTAINER_CLUSTER}"
 
 kubectl run "${POD_NAME}" --generator=run-pod/v1 --image="$IMAGE" \
   --requests "cpu=2,memory=2Gi" --restart=Never \
+  --env="BASE_BRANCH=$BASE_BRANCH" \
   --command -- bash /init-actions/cloudbuild/presubmit.sh
 
 trap 'kubectl delete pods "${POD_NAME}"' EXIT


### PR DESCRIPTION
This avoids running tests for init actions that were changed upstream.