### PR TITLE
Add init script for Rapids Spark XGBoost4j

### DIFF
--- a/spark-gpu/README.md
+++ b/spark-gpu/README.md
@@ -76,27 +76,27 @@ training with RAPIDS Spark GPU APIs. Additional examples
 
 To submit such a job run:
     ```bash
-        export STORAGE_BUCKET=dongm-gcp-shared
-        export MAIN_CLASS=ai.rapids.spark.examples.mortgage.GPUMain
-        export RAPIDS_JARS=gs://$STORAGE_BUCKET/sparkGPU_init/sample_xgboost_apps-0.1.4-jar-with-dependencies.jar
-        export DATA_PATH=hdfs:///tmp/xgboost4j_spark/mortgage/csv
-        export TREE_METHOD=gpu_hist
-        export SPARK_NUM_EXECUTORS=4
+    export STORAGE_BUCKET=dongm-gcp-shared
+    export MAIN_CLASS=ai.rapids.spark.examples.mortgage.GPUMain
+    export RAPIDS_JARS=gs://$STORAGE_BUCKET/sparkGPU_init/sample_xgboost_apps-0.1.4-jar-with-dependencies.jar
+    export DATA_PATH=hdfs:///tmp/xgboost4j_spark/mortgage/csv
+    export TREE_METHOD=gpu_hist
+    export SPARK_NUM_EXECUTORS=4
 
-        gcloud beta dataproc jobs submit spark \
-          --cluster=$CLUSTER_NAME \
-          --region=$REGION \
-          --class=$MAIN_CLASS \
-          --jars=$RAPIDS_JARS \
-          --properties=spark.executor.cores=1,spark.executor.instances=${SPARK_NUM_EXECUTORS},spark.executor.memory=8G,spark.executorEnv.LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu:/usr/local/cuda-10.0/lib64:${LD_LIBRARY_PATH} \
-          -- \
-          -format=csv \
-          -numRound=100 \
-          -numWorkers=${SPARK_NUM_EXECUTORS} \
-          -treeMethod=${TREE_METHOD} \
-          -trainDataPath=${DATA_PATH}/train/mortgage_train_merged.csv \
-           -evalDataPath=${DATA_PATH}/test/mortgage_eval_merged.csv \
-           -maxDepth=8 
+    gcloud beta dataproc jobs submit spark \
+      --cluster=$CLUSTER_NAME \
+      --region=$REGION \
+      --class=$MAIN_CLASS \
+      --jars=$RAPIDS_JARS \
+      --properties=spark.executor.cores=1,spark.executor.instances=${SPARK_NUM_EXECUTORS},spark.executor.memory=8G,spark.executorEnv.LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu:/usr/local/cuda-10.0/lib64:${LD_LIBRARY_PATH} \
+      -- \
+      -format=csv \
+      -numRound=100 \
+      -numWorkers=${SPARK_NUM_EXECUTORS} \
+      -treeMethod=${TREE_METHOD} \
+      -trainDataPath=${DATA_PATH}/train/mortgage_train_merged.csv \
+       -evalDataPath=${DATA_PATH}/test/mortgage_eval_merged.csv \
+       -maxDepth=8 
     ```
 
 

--- a/spark-gpu/README.md
+++ b/spark-gpu/README.md
@@ -1,0 +1,141 @@
+# RAPIDS Spark GPU
+
+This initialization action deploy the dependency of RAPIDS spark GPU(https://github.com/rapidsai/spark-examples) on a
+[Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster.
+
+Prerequisites
+-------------
+* Apache Spark 2.3+
+* Hardware Requirements
+  * NVIDIA Pascal™ GPU architecture or better (V100, P100, T4 and later)
+  * Multi-node clusters with homogenous GPU configuration
+* Software Requirements
+  * NVIDIA driver 410.48+
+  * CUDA V10.0/9.2
+  * NCCL 2.4.7 and later
+* `EXCLUSIVE_PROCESS` must be set for all GPUs in each NodeManager.
+* `spark.dynamicAllocation.enabled` must be set to False for spark
+
+Our initialization action does the following:
+
+1.  [install nvidia GPU driver, cuda 10.0 toolkit and nccl 2.4.8](internal/install-gpu-driver.sh)
+
+## Using this initialization action
+
+You can use this initialization action to create a new Dataproc cluster with
+all prerequisites installed:
+
+1.  Using the `gcloud` command to create a new cluster with this initialization
+    action. The following command will create a new cluster named
+    `<CLUSTER_NAME>`. Before the init script fully merged into `<dataproc-initialization-actions>` bucket, user need to copy the sparkgpu initialization script into a accessible GCS and into following structure. Ubuntu is recommended as CUDA support ubuntu, debian could be used by modifying `image-version` and `linux-dist` accordingly.
+
+    ```
+    /$STORAGE_BUCKET/sparkgpu/rapids.sh
+    /$STORAGE_BUCKET/sparkgpu/internal/install-gpu-driver*.sh
+    ```  
+
+    ```bash
+    export CLUSTER_NAME=sparkgpu
+    export ZONE=us-central1-b
+    export REGION=us-central1
+    export STORAGE_BUCKET=dataproc-initialization-actions
+    export NUM_GPUS=2
+    export NUM_WORKERS=2
+    
+    gcloud beta dataproc clusters create $CLUSTER_NAME  \
+        --zone $ZONE \
+        --region $REGION \
+        --master-machine-type n1-standard-32 \
+        --worker-accelerator type=nvidia-tesla-t4,count=$NUM_GPUS \
+        --worker-machine-type n1-standard-32 \
+        --num-worker-local-ssds 1 \
+        --num-workers $NUM_WORKERS \
+        --image-version 1.4-ubuntu18 \
+        --bucket $STORAGE_BUCKET \
+        --metadata zeppelin-port=8081,INIT_ACTIONS_REPO="gs://$STORAGE_BUCKET",linux-dist="ubuntu" \
+        --initialization-actions gs://$STORAGE_BUCKET/spark-gpu/rapids.sh \
+        --optional-components=ZEPPELIN \
+        --subnet=default \
+        --properties 'spark:spark.dynamicAllocation.enabled=false,spark:spark.shuffle.service.enabled=false' \
+        --enable-component-gateway       
+    ```
+
+2.  Once the cluster has been created, yarn resource manager could be accessed on port `8088` on the Dataproc master node. 
+
+To connect to the dataproc web interface, you will need to create an SSH tunnel as
+described in the
+[dataproc web interfaces](https://cloud.google.com/dataproc/cluster-web-interfaces)
+documentation. 
+
+See
+[the Mortgage example](https://github.com/rapidsai/spark-examples/tree/master/examples/apps/scala/src/main/scala/ai/rapids/spark/examples/mortgage)
+that demonstrates end to end XGBoost4j in spark including data pre-processing and model
+training with RAPIDS Spark GPU APIs. Additional examples
+[are available](https://github.com/rapidsai/spark-examples/tree/master/examples). See the
+[RAPIDS Spark GPU API documentation](https://github.com/rapidsai/spark-examples/tree/master/api-docs) for API details.
+
+To submit such a job run:
+    ```bash
+        export STORAGE_BUCKET=dongm-gcp-shared
+        export MAIN_CLASS=ai.rapids.spark.examples.mortgage.GPUMain
+        export RAPIDS_JARS=gs://$STORAGE_BUCKET/sparkGPU_init/sample_xgboost_apps-0.1.4-jar-with-dependencies.jar
+        export DATA_PATH=hdfs:///tmp/xgboost4j_spark/mortgage/csv
+        export TREE_METHOD=gpu_hist
+        export SPARK_NUM_EXECUTORS=4
+
+        gcloud beta dataproc jobs submit spark \
+          --cluster=$CLUSTER_NAME \
+          --region=$REGION \
+          --class=$MAIN_CLASS \
+          --jars=$RAPIDS_JARS \
+          --properties=spark.executor.cores=1,spark.executor.instances=${SPARK_NUM_EXECUTORS},spark.executor.memory=8G,spark.executorEnv.LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu:/usr/local/cuda-10.0/lib64:${LD_LIBRARY_PATH} \
+          -- \
+          -format=csv \
+          -numRound=100 \
+          -numWorkers=${SPARK_NUM_EXECUTORS} \
+          -treeMethod=${TREE_METHOD} \
+          -trainDataPath=${DATA_PATH}/train/mortgage_train_merged.csv \
+           -evalDataPath=${DATA_PATH}/test/mortgage_eval_merged.csv \
+           -maxDepth=8 
+    ```
+
+
+RAPIDS Spark GPU is a relatively young project with APIs evolving quickly. If you
+encounter unexpected errors or have feature requests, please file them at the
+relevant [RAPIDS Spark example repo](https://github.com/rapidsai/spark-examples).
+
+### Options
+
+#### GPU Types & Driver Configuration
+
+By default, these initialization actions install a CUDA 10.0 with NVIDIA 418 driver. If you wish
+to install a different driver version, `metadata` need to be passed into initial action. Available options below:
+
+```
+    gpu-driver-version='418'
+    cuda-url='https://developer.download.nvidia.com/compute/cuda/repos/
+    cuda-version='10-0'
+    nccl-url='https://developer.nvidia.com/compute/machine-learning/nccl/secure/v2.4/prod/nccl-repo-ubuntu1804-2.4.8-ga-cuda10.0_1-1_amd64.deb'
+    nccl-version='2.4.8'
+```
+
+#### Initialization Action Source
+
+The RAPIDS Spark GPU initialization action steps are performed by [rapids.sh](rapids.sh)
+which runs additional scripts downloaded from `rapids` directory in
+[Dataproc Initialization Actions repo](https://pantheon.corp.google.com/storage/browser/dataproc-initialization-actions)
+GCS bucket by default:
+
+## Important notes
+
+*   RAPIDS Spark GPU is supported on Pascal or newer GPU architectures (Tesla K80s will
+    _not_ work with RAPIDS). See
+    [list](https://cloud.google.com/compute/docs/gpus/) of available GPU types
+    by GCP region.
+*   You must set a GPU accelerator type for worker nodes, else
+    the GPU driver install will fail and the cluster will report an error state.
+*   When running RAPIDS Spark GPU with multiple attached GPUs, We recommend an
+    n1-standard-32 worker machine type or better to ensure sufficient
+    host-memory for buffering data to and from GPUs. When running with a single
+    attached GPU, GCP only permits machine types up to 24 vCPUs.
+

--- a/spark-gpu/README.md
+++ b/spark-gpu/README.md
@@ -11,9 +11,9 @@ Prerequisites
   * Multi-node clusters with homogenous GPU configuration
 * Software Requirements
   * NVIDIA driver 410.48+
-  * CUDA V10.0/9.2
+  * CUDA V10.1/10.0/9.2
   * NCCL 2.4.7 and later
-* `EXCLUSIVE_PROCESS` must be set for all GPUs in each NodeManager.
+* `EXCLUSIVE_PROCESS` must be set for all GPUs in each NodeManager.(Initialization script provided in this guide will set this mode by default)
 * `spark.dynamicAllocation.enabled` must be set to False for spark
 
 Our initialization action does the following:
@@ -30,34 +30,38 @@ all prerequisites installed:
     `<CLUSTER_NAME>`. Before the init script fully merged into `<dataproc-initialization-actions>` bucket, user need to copy the sparkgpu initialization script into a accessible GCS and into following structure. Ubuntu is recommended as CUDA support ubuntu, debian could be used by modifying `image-version` and `linux-dist` accordingly.
 
     ```
-    /$STORAGE_BUCKET/sparkgpu/rapids.sh
-    /$STORAGE_BUCKET/sparkgpu/internal/install-gpu-driver*.sh
-    ```  
-
+    /$GCS_BUCKET/sparkgpu/rapids.sh
+    /$GCS_BUCKET/sparkgpu/internal/install-gpu-driver*.sh
+    ```
+    
     ```bash
-    export CLUSTER_NAME=sparkgpu
+    export CLUSTER_NAME=my-gpu-cluster
     export ZONE=us-central1-b
     export REGION=us-central1
-    export STORAGE_BUCKET=dataproc-initialization-actions
+    export GCS_BUCKET=my-bucket
+    export INIT_ACTIONS_BUCKET=my-bucket
     export NUM_GPUS=2
     export NUM_WORKERS=2
-    
+     
     gcloud beta dataproc clusters create $CLUSTER_NAME  \
         --zone $ZONE \
         --region $REGION \
         --master-machine-type n1-standard-32 \
+        --master-boot-disk-size 50 \
         --worker-accelerator type=nvidia-tesla-t4,count=$NUM_GPUS \
         --worker-machine-type n1-standard-32 \
+        --worker-boot-disk-size 50 \
         --num-worker-local-ssds 1 \
         --num-workers $NUM_WORKERS \
         --image-version 1.4-ubuntu18 \
-        --bucket $STORAGE_BUCKET \
-        --metadata zeppelin-port=8081,INIT_ACTIONS_REPO="gs://$STORAGE_BUCKET",linux-dist="ubuntu" \
-        --initialization-actions gs://$STORAGE_BUCKET/spark-gpu/rapids.sh \
-        --optional-components=ZEPPELIN \
+        --bucket $GCS_BUCKET \
+        --metadata JUPYTER_PORT=8123,INIT_ACTIONS_REPO="gs://$INIT_ACTIONS_BUCKET",linux-dist="ubuntu",
+        GCS_BUCKET="gs://$GCS_BUCKET" \
+        --initialization-actions gs://$INIT_ACTIONS_BUCKET/spark-gpu/rapids.sh \
+        --optional-components=ANACONDA,JUPYTER \
         --subnet=default \
-        --properties 'spark:spark.dynamicAllocation.enabled=false,spark:spark.shuffle.service.enabled=false' \
-        --enable-component-gateway       
+        --properties '^#^spark:spark.dynamicAllocation.enabled=false#spark:spark.shuffle.service.enabled=false#spark:spark.submit.pyFiles=/usr/lib/spark/python/lib/xgboost4j-spark_2.11-1.0.0-Beta2.jar#spark:spark.jars=/usr/lib/spark/jars/xgboost4j-spark_2.11-1.0.0-Beta2.jar,/usr/lib/spark/jars/xgboost4j_2.11-1.0.0-Beta2.jar,/usr/lib/spark/jars/cudf-0.9.1-cuda10.jar' \
+        --enable-component-gateway   
     ```
 
 2.  Once the cluster has been created, yarn resource manager could be accessed on port `8088` on the Dataproc master node. 
@@ -75,29 +79,31 @@ training with RAPIDS Spark GPU APIs. Additional examples
 [RAPIDS Spark GPU API documentation](https://github.com/rapidsai/spark-examples/tree/master/api-docs) for API details.
 
 To submit such a job run:
-    ```bash
-    export STORAGE_BUCKET=dongm-gcp-shared
+
+ ```bash
     export MAIN_CLASS=ai.rapids.spark.examples.mortgage.GPUMain
-    export RAPIDS_JARS=gs://$STORAGE_BUCKET/sparkGPU_init/sample_xgboost_apps-0.1.4-jar-with-dependencies.jar
-    export DATA_PATH=hdfs:///tmp/xgboost4j_spark/mortgage/csv
+    export RAPIDS_JARS=gs://$GCS_BUCKET/spark-gpu/sample_xgboost_apps-0.1.4-jar-with-dependencies.jar
+    export DATA_PATH=$GCS_BUCKET
     export TREE_METHOD=gpu_hist
     export SPARK_NUM_EXECUTORS=4
+    export CLUSTER_NAME=my-gpu-cluster
+    export REGION=us-central1
 
     gcloud beta dataproc jobs submit spark \
-      --cluster=$CLUSTER_NAME \
-      --region=$REGION \
-      --class=$MAIN_CLASS \
-      --jars=$RAPIDS_JARS \
-      --properties=spark.executor.cores=1,spark.executor.instances=${SPARK_NUM_EXECUTORS},spark.executor.memory=8G,spark.executorEnv.LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu:/usr/local/cuda-10.0/lib64:${LD_LIBRARY_PATH} \
-      -- \
-      -format=csv \
-      -numRound=100 \
-      -numWorkers=${SPARK_NUM_EXECUTORS} \
-      -treeMethod=${TREE_METHOD} \
-      -trainDataPath=${DATA_PATH}/train/mortgage_train_merged.csv \
-       -evalDataPath=${DATA_PATH}/test/mortgage_eval_merged.csv \
-       -maxDepth=8 
-    ```
+        --cluster=$CLUSTER_NAME \
+        --region=$REGION \
+        --class=$MAIN_CLASS \
+        --jars=$RAPIDS_JARS \
+        --properties=spark.executor.cores=1,spark.executor.instances=${SPARK_NUM_EXECUTORS},spark.executor.memory=8G,spark.executorEnv.LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu:/usr/local/cuda-10.0/lib64:${LD_LIBRARY_PATH} \
+        -- \
+        -format=csv \
+        -numRound=100 \
+        -numWorkers=${SPARK_NUM_EXECUTORS} \
+        -treeMethod=${TREE_METHOD} \
+        -trainDataPath=${DATA_PATH}/mortgage-small/train/mortgage_small.csv \
+        -evalDataPath=${DATA_PATH}/mortgage-small/eval/mortgage_small.csv \
+        -maxDepth=8  
+ ```
 
 
 RAPIDS Spark GPU is a relatively young project with APIs evolving quickly. If you
@@ -112,8 +118,6 @@ By default, these initialization actions install a CUDA 10.0 with NVIDIA 418 dri
 to install a different driver version, `metadata` need to be passed into initial action. Available options below:
 
 ```
-    gpu-driver-version='418'
-    cuda-url='https://developer.download.nvidia.com/compute/cuda/repos/
     cuda-version='10-0'
     nccl-url='https://developer.nvidia.com/compute/machine-learning/nccl/secure/v2.4/prod/nccl-repo-ubuntu1804-2.4.8-ga-cuda10.0_1-1_amd64.deb'
     nccl-version='2.4.8'

--- a/spark-gpu/internal/install-gpu-driver-debian.sh
+++ b/spark-gpu/internal/install-gpu-driver-debian.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+readonly DEFAULT_GPU_DRIVER_URL='http://us.download.nvidia.com/tesla/418.87/NVIDIA-Linux-x86_64-418.87.00.run'
+readonly GPU_DRIVER_URL=$(/usr/share/google/get_metadata_value attributes/gpu-driver-url ||
+  echo -n "${DEFAULT_GPU_DRIVER_URL}")
+
+readonly DEFAULT_CUDA_URL='https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_410.48_linux'
+readonly CUDA_URL=$(/usr/share/google/get_metadata_value attributes/gpu-cuda-url ||
+  echo -n "${DEFAULT_CUDA_URL}")
+
+readonly DEFAULT_CUDA_VERSION='10-0'
+readonly CUDA_VERSION=$(/usr/share/google/get_metadata_value attributes/cuda-version ||
+  echo -n "${DEFAULT_CUDA_VERSION}")
+
+readonly DEFAULT_NCCL_URL='https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/nvidia-machine-learning-repo-ubuntu1804_1.0.0-1_amd64.deb'
+readonly NCCL_URL=$(/usr/share/google/get_metadata_value attributes/nccl-url ||
+  echo -n "${DEFAULT_NCCL_URL}")
+
+readonly DEFAULT_NCCL_VERSION='2.4.8'
+readonly NCCL_VERSION=$(/usr/share/google/get_metadata_value attributes/nccl-version ||
+  echo -n "${DEFAULT_NCCL_VERSION}")
+
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y pciutils "linux-headers-$(uname -r)"
+
+wget --progress=dot:mega -O driver.run "${GPU_DRIVER_URL}"
+chmod +x "./driver.run"
+"./driver.run" --silent
+
+wget --progress=dot:mega -O cuda.run "${CUDA_URL}"
+chmod +x "./cuda.run"
+"./cuda.run" --silent --toolkit --no-opengl-libs
+
+wget --progress=dot:mega -O nccl.deb "${GPU_NCCL_URL}"
+chmod +x "./nccl.deb"
+dpkg -i nccl.deb
+apt update
+apt install "libnccl2=${NCCL_VERSION}-1+cuda${CUDA_VERSION//\-/\.}" "libnccl-dev=${NCCL_VERSION}-1+cuda${CUDA_VERSION//\-/\.}" -y 
+
+/usr/bin/nvidia-smi -c EXCLUSIVE_PROCESS

--- a/spark-gpu/internal/install-gpu-driver-ubuntu.sh
+++ b/spark-gpu/internal/install-gpu-driver-ubuntu.sh
@@ -2,14 +2,6 @@
 
 set -euxo pipefail
 
-readonly DEFAULT_GPU_DRIVER_VERSION='418'
-readonly GPU_DRIVER_VERSION=$(/usr/share/google/get_metadata_value attributes/gpu-driver-version ||
-  echo -n "${DEFAULT_GPU_DRIVER_VERSION}")
-
-readonly DEFAULT_CUDA_URL='https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-repo-ubuntu1804_10.0.130-1_amd64.deb'
-readonly CUDA_URL=$(/usr/share/google/get_metadata_value attributes/cuda-url ||
-  echo -n "${DEFAULT_CUDA_URL}")
-
 readonly DEFAULT_CUDA_VERSION='10-0'
 readonly CUDA_VERSION=$(/usr/share/google/get_metadata_value attributes/cuda-version ||
   echo -n "${DEFAULT_CUDA_VERSION}")
@@ -24,17 +16,18 @@ readonly NCCL_VERSION=$(/usr/share/google/get_metadata_value attributes/nccl-ver
 
 apt-get update
 apt-get install build-essential
-DEBIAN_FRONTEND=noninteractive apt-get install -y pciutils "linux-headers-$(uname -r)"
 
-add-apt-repository ppa:graphics-drivers/ppa -y
-apt update
-apt install "nvidia-driver-${GPU_DRIVER_VERSION}" -y 
-wget --progress=dot:mega -O cuda.deb "${CUDA_URL}"
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
+mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
+apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
+apt-get update
 
-dpkg -i cuda.deb 
-apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub"
-apt update
-apt install "cuda-${CUDA_VERSION}" -y 
+if [[ "${CUDA_VERSION}" != '10-0' ]]; then
+  apt-get -y install cuda
+else
+  apt-get -y install cuda-10-0
+fi
 
 wget --progress=dot:mega -O nccl.deb "${NCCL_URL}"
 dpkg -i nccl.deb

--- a/spark-gpu/internal/install-gpu-driver-ubuntu.sh
+++ b/spark-gpu/internal/install-gpu-driver-ubuntu.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+readonly DEFAULT_GPU_DRIVER_VERSION='418'
+readonly GPU_DRIVER_VERSION=$(/usr/share/google/get_metadata_value attributes/gpu-driver-version ||
+  echo -n "${DEFAULT_GPU_DRIVER_VERSION}")
+
+readonly DEFAULT_CUDA_URL='https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-repo-ubuntu1804_10.0.130-1_amd64.deb'
+readonly CUDA_URL=$(/usr/share/google/get_metadata_value attributes/cuda-url ||
+  echo -n "${DEFAULT_CUDA_URL}")
+
+readonly DEFAULT_CUDA_VERSION='10-0'
+readonly CUDA_VERSION=$(/usr/share/google/get_metadata_value attributes/cuda-version ||
+  echo -n "${DEFAULT_CUDA_VERSION}")
+
+readonly DEFAULT_NCCL_URL='https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/nvidia-machine-learning-repo-ubuntu1804_1.0.0-1_amd64.deb'
+readonly NCCL_URL=$(/usr/share/google/get_metadata_value attributes/nccl-url ||
+  echo -n "${DEFAULT_NCCL_URL}")
+
+readonly DEFAULT_NCCL_VERSION='2.4.8'
+readonly NCCL_VERSION=$(/usr/share/google/get_metadata_value attributes/nccl-version ||
+  echo -n "${DEFAULT_NCCL_VERSION}")
+
+apt-get update
+apt-get install build-essential
+DEBIAN_FRONTEND=noninteractive apt-get install -y pciutils "linux-headers-$(uname -r)"
+
+add-apt-repository ppa:graphics-drivers/ppa -y
+apt update
+apt install "nvidia-driver-${GPU_DRIVER_VERSION}" -y 
+wget --progress=dot:mega -O cuda.deb "${CUDA_URL}"
+
+dpkg -i cuda.deb 
+apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub"
+apt update
+apt install "cuda-${CUDA_VERSION}" -y 
+
+wget --progress=dot:mega -O nccl.deb "${NCCL_URL}"
+dpkg -i nccl.deb
+apt update
+apt install "libnccl2=${NCCL_VERSION}-1+cuda${CUDA_VERSION//\-/\.}" "libnccl-dev=${NCCL_VERSION}-1+cuda${CUDA_VERSION//\-/\.}" -y 
+
+/usr/bin/nvidia-smi -c EXCLUSIVE_PROCESS
+
+
+

--- a/spark-gpu/rapids.sh
+++ b/spark-gpu/rapids.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+readonly ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+readonly LINUX_DIST=$(/usr/share/google/get_metadata_value attributes/linux-dist)
+
+readonly DEAFULT_INIT_ACTIONS_REPO=gs://dongm-gcp-shared
+readonly INIT_ACTIONS_REPO="$(/usr/share/google/get_metadata_value attributes/INIT_ACTIONS_REPO ||
+  echo ${DEAFULT_INIT_ACTIONS_REPO})"
+
+echo "Cloning RAPIDS initialization action from '${INIT_ACTIONS_REPO}' ..."
+RAPIDS_INIT_ACTION_DIR=$(mktemp -d -t rapids-init-action-XXXX)
+readonly RAPIDS_INIT_ACTION_DIR
+gsutil -m rsync -r "${INIT_ACTIONS_REPO}/spark-gpu" "${RAPIDS_INIT_ACTION_DIR}"
+
+if [[ "${LINUX_DIST}" == 'ubuntu' ]]; then
+  mv "${RAPIDS_INIT_ACTION_DIR}/internal/install-gpu-driver-ubuntu.sh" "${RAPIDS_INIT_ACTION_DIR}/internal/install-gpu-driver.sh"
+else
+  mv "${RAPIDS_INIT_ACTION_DIR}/internal/install-gpu-driver-debian.sh" "${RAPIDS_INIT_ACTION_DIR}/internal/install-gpu-driver.sh"
+fi
+find "${RAPIDS_INIT_ACTION_DIR}" -name '*.sh' -exec chmod +x {} \;
+
+if [[ "${ROLE}" != 'Master' ]]; then
+  # Ensure we have GPU drivers installed.
+  "${RAPIDS_INIT_ACTION_DIR}/internal/install-gpu-driver.sh"
+else
+  wget "https://rapidsai-data.s3.us-east-2.amazonaws.com/spark/mortgage.zip"
+  unzip "mortgage.zip"
+  hadoop fs -mkdir "/tmp/xgboost4j_spark"
+  hadoop fs -copyFromLocal mortgage "/tmp/xgboost4j_spark/mortgage"
+fi
+
+
+

--- a/spark-gpu/rapids.sh
+++ b/spark-gpu/rapids.sh
@@ -5,9 +5,13 @@ set -euxo pipefail
 readonly ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
 readonly LINUX_DIST=$(/usr/share/google/get_metadata_value attributes/linux-dist)
 
-readonly DEAFULT_INIT_ACTIONS_REPO=gs://dongm-gcp-shared
+readonly DEAFULT_INIT_ACTIONS_REPO=gs://dataproc-initialization-actions
 readonly INIT_ACTIONS_REPO="$(/usr/share/google/get_metadata_value attributes/INIT_ACTIONS_REPO ||
   echo ${DEAFULT_INIT_ACTIONS_REPO})"
+
+readonly DEAFULT_GCS_BUCKET=gs://my-bucket
+readonly GCS_BUCKET="$(/usr/share/google/get_metadata_value attributes/GCS_BUCKET ||
+  echo ${DEAFULT_GCS_BUCKET})"
 
 echo "Cloning RAPIDS initialization action from '${INIT_ACTIONS_REPO}' ..."
 RAPIDS_INIT_ACTION_DIR=$(mktemp -d -t rapids-init-action-XXXX)
@@ -25,10 +29,10 @@ if [[ "${ROLE}" != 'Master' ]]; then
   # Ensure we have GPU drivers installed.
   "${RAPIDS_INIT_ACTION_DIR}/internal/install-gpu-driver.sh"
 else
-  wget "https://rapidsai-data.s3.us-east-2.amazonaws.com/spark/mortgage.zip"
-  unzip "mortgage.zip"
-  hadoop fs -mkdir "/tmp/xgboost4j_spark"
-  hadoop fs -copyFromLocal mortgage "/tmp/xgboost4j_spark/mortgage"
+  gsutil cp ${GCS_BUCKET}/xgboost4j-spark_2.11-1.0.0-Beta2.jar /usr/lib/spark/python/lib/
+  gsutil cp ${GCS_BUCKET}/xgboost4j-spark_2.11-1.0.0-Beta2.jar /usr/lib/spark/jars/
+  gsutil cp ${GCS_BUCKET}/xgboost4j_2.11-1.0.0-Beta2.jar /usr/lib/spark/jars/
+  gsutil cp ${GCS_BUCKET}/cudf-0.9.1-cuda10.jar /usr/lib/spark/jars/
 fi
 
 


### PR DESCRIPTION
This pull request add dataproc init script for rapids spark xgboost4j. https://github.com/rapidsai/spark-examples. It makes sure the cluster initialized by the right driver/cuda/nccl … other dependencies and with the right setting (dynamic allocation off, persistent mode on). This is different from rapids script as GPU is not needed for master node and there is less software dependency.

The script is customizable for dataproc linux OS version, GPU driver version, CUDA toolkit version and NCCL version. But the prerequisite needs to be met as indicated in README. please refer to https://github.com/rapidsai/spark-examples/tree/master/getting-started-guides/csp/gcp for the same script, we can point that to dataproc initiation script to GCP repo once this checked in. 